### PR TITLE
feat: add default nil values to AnalyticsInterface optional parameters

### DIFF
--- a/Sources/MetaRouter/analytics/AnalyticsInterface.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsInterface.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public protocol AnalyticsInterface: AnyObject, Sendable {
-    func track(_ event: String, properties: [String: CodableValue]?)
-    func identify(_ userId: String, traits: [String: CodableValue]?)
-    func group(_ groupId: String, traits: [String: CodableValue]?)
-    func screen(_ name: String, properties: [String: CodableValue]?)
-    func page(_ name: String, properties: [String: CodableValue]?)
+    func track(_ event: String, properties: [String: CodableValue]? = nil)
+    func identify(_ userId: String, traits: [String: CodableValue]? = nil)
+    func group(_ groupId: String, traits: [String: CodableValue]? = nil)
+    func screen(_ name: String, properties: [String: CodableValue]? = nil)
+    func page(_ name: String, properties: [String: CodableValue]? = nil)
     func alias(_ newUserId: String)
     func enableDebugLogging()
     func getDebugInfo() -> [String: CodableValue]


### PR DESCRIPTION
This fixes compilation errors when calling track methods without properties parameter.

🤖 Generated with [Claude Code](https://claude.ai/code)