### PR TITLE
fix: remove PII from device context, align with Android

### DIFF
--- a/Sources/MetaRouter/context/DeviceContextProvider.swift
+++ b/Sources/MetaRouter/context/DeviceContextProvider.swift
@@ -12,7 +12,6 @@ import AppKit
 
 struct DeviceSnapshot: Sendable {
     let model: String
-    let name: String
     let systemName: String
     let systemVersion: String
     let userInterfaceIdiom: Int
@@ -94,9 +93,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
         let currentAdvertisingId = await advertisingIdActor.get()
 
         #if canImport(UIKit)
-        let snapshot = await readDeviceSnapshot()
-
-        // Low-level model code (e.g., "iPhone16,2")
         var sys = utsname(); uname(&sys)
         let modelCode = withUnsafePointer(to: &sys.machine) {
             $0.withMemoryRebound(to: CChar.self, capacity: 1) { ptr in
@@ -104,21 +100,21 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
             }
         }
 
-        let mappedModel = mapDeviceModel(modelCode)
         let type = await deviceTypeFromIdiom(UIDevice.current.userInterfaceIdiom)
 
         return DeviceContext(
             manufacturer: "Apple",
-            model: mappedModel,
-            name: snapshot.name,
+            model: modelCode,
+            name: modelCode,
             type: type,
             advertisingId: currentAdvertisingId
         )
         #elseif canImport(AppKit)
+        let hwModel = macHardwareModel()
         return DeviceContext(
             manufacturer: "Apple",
-            model: macHardwareModel(), // e.g., "Mac14,5"
-            name: Host.current().localizedName ?? ProcessInfo.processInfo.hostName,
+            model: hwModel,
+            name: hwModel,
             type: "macos",
             advertisingId: currentAdvertisingId
         )
@@ -206,7 +202,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
         let d = UIDevice.current
         return DeviceSnapshot(
             model: d.model,
-            name: d.name,
             systemName: d.systemName,
             systemVersion: d.systemVersion,
             userInterfaceIdiom: d.userInterfaceIdiom.rawValue
@@ -267,48 +262,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
 
 
 
-extension DeviceContextProvider {
-    /// Maps iOS device model codes to human-readable names (fallbacks to raw code)
-    private func mapDeviceModel(_ modelCode: String) -> String {
-        let modelMap: [String: String] = [
-            // iPhone (examples)
-            "iPhone14,7": "iPhone 13 mini",
-            "iPhone14,8": "iPhone 13",
-            "iPhone14,2": "iPhone 13 Pro",
-            "iPhone14,3": "iPhone 13 Pro Max",
-            "iPhone15,4": "iPhone 14",
-            "iPhone15,5": "iPhone 14 Plus",
-            "iPhone15,2": "iPhone 14 Pro",
-            "iPhone15,3": "iPhone 14 Pro Max",
-            "iPhone16,1": "iPhone 15 Pro",
-            "iPhone16,2": "iPhone 15 Pro Max",
-            "iPhone16,3": "iPhone 15",
-            "iPhone16,4": "iPhone 15 Plus",
-            "iPhone17,1": "iPhone 16 Pro",
-            "iPhone17,2": "iPhone 16 Pro Max",
-            "iPhone17,3": "iPhone 16",
-            "iPhone17,4": "iPhone 16 Plus",
-            "iPhone17,5": "iPhone 16e",
-            "iPhone18,1": "iPhone 17 Pro",
-            "iPhone18,2": "iPhone 17 Pro Max",
-            "iPhone18,3": "iPhone 17",
-            "iPhone18,4": "iPhone Air",
-
-            // iPad (examples)
-            "iPad13,18": "iPad (10th generation)",
-            "iPad13,19": "iPad (10th generation)",
-            "iPad14,3": "iPad Pro 11-inch (4th generation)",
-            "iPad14,4": "iPad Pro 11-inch (4th generation)",
-            "iPad14,5": "iPad Pro 12.9-inch (6th generation)",
-            "iPad14,6": "iPad Pro 12.9-inch (6th generation)",
-
-            // Simulator
-            "x86_64": "Simulator",
-            "arm64": "Simulator",
-        ]
-        return modelMap[modelCode] ?? modelCode
-    }
-}
 
 
 private actor ContextActor {

--- a/Sources/MetaRouter/context/DeviceContextProvider.swift
+++ b/Sources/MetaRouter/context/DeviceContextProvider.swift
@@ -105,7 +105,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
         return DeviceContext(
             manufacturer: "Apple",
             model: modelCode,
-            name: modelCode,
             type: type,
             advertisingId: currentAdvertisingId
         )
@@ -114,7 +113,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
         return DeviceContext(
             manufacturer: "Apple",
             model: hwModel,
-            name: hwModel,
             type: "macos",
             advertisingId: currentAdvertisingId
         )
@@ -122,7 +120,6 @@ public final class DeviceContextProvider: ContextProvider, @unchecked Sendable {
         return DeviceContext(
             manufacturer: "Apple",
             model: "unknown",
-            name: "unknown",
             type: "unknown",
             advertisingId: currentAdvertisingId
         )

--- a/Sources/MetaRouter/types/EventContext.swift
+++ b/Sources/MetaRouter/types/EventContext.swift
@@ -19,14 +19,12 @@ public struct AppContext: Codable, Sendable {
 public struct DeviceContext: Codable, Sendable {
     public let manufacturer: String
     public let model: String
-    public let name: String
     public let type: String
     public let advertisingId: String?
 
-    public init(manufacturer: String, model: String, name: String, type: String, advertisingId: String? = nil) {
+    public init(manufacturer: String, model: String, type: String, advertisingId: String? = nil) {
         self.manufacturer = manufacturer
         self.model = model
-        self.name = name
         self.type = type
         self.advertisingId = advertisingId
     }

--- a/Tests/MetaRouterTests/ContextProviderTests.swift
+++ b/Tests/MetaRouterTests/ContextProviderTests.swift
@@ -21,7 +21,7 @@ final class ContextProviderTests: XCTestCase {
         let app = AppContext(
             name: "TestApp", version: "1.0", build: "123", namespace: "com.test.app")
         let device = DeviceContext(
-            manufacturer: "Apple", model: "iPhone15,2", name: "Test Device", type: "ios")
+            manufacturer: "Apple", model: "iPhone15,2", type: "ios")
         let library = LibraryContext(name: "test-sdk", version: "1.0.0")
         let os = OSContext(name: "iOS", version: "17.0")
         let screen = ScreenContext(density: 3.0, width: 1179, height: 2556)
@@ -52,7 +52,7 @@ final class ContextProviderTests: XCTestCase {
         let app = AppContext(
             name: "TestApp", version: "1.0", build: "123", namespace: "com.test.app")
         let device = DeviceContext(
-            manufacturer: "Apple", model: "iPhone15,2", name: "Test Device", type: "ios")
+            manufacturer: "Apple", model: "iPhone15,2", type: "ios")
         let library = LibraryContext(name: "test-sdk", version: "1.0.0")
         let os = OSContext(name: "iOS", version: "17.0")
         let screen = ScreenContext(density: 3.0, width: 1179, height: 2556)
@@ -131,7 +131,6 @@ final class ContextProviderTests: XCTestCase {
 
         XCTAssertEqual(context.device.manufacturer, "Apple")
         XCTAssertFalse(context.device.model.isEmpty)
-        XCTAssertFalse(context.device.name.isEmpty)
         XCTAssertTrue(
             context.device.type == "ios" || context.device.type == "macos")
     }
@@ -243,7 +242,7 @@ final class ContextProviderTests: XCTestCase {
         let app = AppContext(
             name: "TestApp", version: "1.0", build: "123", namespace: "com.test.app")
         let device = DeviceContext(
-            manufacturer: "Apple", model: "iPhone15,2", name: "Test Device", type: "ios")
+            manufacturer: "Apple", model: "iPhone15,2", type: "ios")
         let library = LibraryContext(name: "test-sdk", version: "1.0.0")
         let os = OSContext(name: "iOS", version: "17.0")
         let screen = ScreenContext(density: 3.0, width: 1179, height: 2556)
@@ -283,7 +282,7 @@ final class ContextProviderTests: XCTestCase {
         let app = AppContext(
             name: "TestApp", version: "1.0", build: "123", namespace: "com.test.app")
         let device = DeviceContext(
-            manufacturer: "Apple", model: "iPhone15,2", name: "Test Device", type: "ios")
+            manufacturer: "Apple", model: "iPhone15,2", type: "ios")
         let library = LibraryContext(name: "test-sdk", version: "1.0.0")
         let os = OSContext(name: "iOS", version: "17.0")
         let screen = ScreenContext(density: 3.0, width: 1179, height: 2556)
@@ -323,7 +322,6 @@ final class ContextProviderTests: XCTestCase {
         let device = DeviceContext(
             manufacturer: "Apple",
             model: "iPhone15,2",
-            name: "Test Device",
             type: "ios",
             advertisingId: "12345678-1234-1234-1234-123456789012"
         )
@@ -335,7 +333,6 @@ final class ContextProviderTests: XCTestCase {
         let device = DeviceContext(
             manufacturer: "Apple",
             model: "iPhone15,2",
-            name: "Test Device",
             type: "ios"
         )
 
@@ -381,7 +378,6 @@ final class ContextProviderTests: XCTestCase {
         let device = DeviceContext(
             manufacturer: "Apple",
             model: "iPhone15,2",
-            name: "Test Device",
             type: "ios",
             advertisingId: "TEST-IDFA-UUID"
         )
@@ -395,7 +391,6 @@ final class ContextProviderTests: XCTestCase {
 
         XCTAssertEqual(device.manufacturer, decoded.manufacturer)
         XCTAssertEqual(device.model, decoded.model)
-        XCTAssertEqual(device.name, decoded.name)
         XCTAssertEqual(device.type, decoded.type)
         XCTAssertEqual(device.advertisingId, decoded.advertisingId)
     }
@@ -404,7 +399,6 @@ final class ContextProviderTests: XCTestCase {
         let device = DeviceContext(
             manufacturer: "Apple",
             model: "iPhone15,2",
-            name: "Test Device",
             type: "ios"
         )
 
@@ -417,7 +411,6 @@ final class ContextProviderTests: XCTestCase {
 
         XCTAssertEqual(device.manufacturer, decoded.manufacturer)
         XCTAssertEqual(device.model, decoded.model)
-        XCTAssertEqual(device.name, decoded.name)
         XCTAssertEqual(device.type, decoded.type)
         XCTAssertNil(decoded.advertisingId)
     }

--- a/Tests/MetaRouterTests/DiskStorageTests.swift
+++ b/Tests/MetaRouterTests/DiskStorageTests.swift
@@ -115,7 +115,7 @@ final class DiskStorageTests: XCTestCase {
 private func makeTestEvent(messageId: String = "mid") -> EnrichedEventPayload {
     let ctx = EventContext(
         app: AppContext(name: "a", version: "1", build: "1", namespace: "a"),
-        device: DeviceContext(manufacturer: "a", model: "m", name: "n", type: "t"),
+        device: DeviceContext(manufacturer: "a", model: "m", type: "t"),
         library: LibraryContext(name: "l", version: "1"),
         os: OSContext(name: "iOS", version: "1"),
         screen: ScreenContext(density: 2.0, width: 1, height: 1),

--- a/Tests/MetaRouterTests/DispatcherTests.swift
+++ b/Tests/MetaRouterTests/DispatcherTests.swift
@@ -45,7 +45,7 @@ private final class StubNetworking: Networking, @unchecked Sendable {
 private func makeTestEvent(messageId: String = "mid") -> EnrichedEventPayload {
     let ctx = EventContext(
         app: AppContext(name: "a", version: "1", build: "1", namespace: "a"),
-        device: DeviceContext(manufacturer: "a", model: "m", name: "n", type: "t"),
+        device: DeviceContext(manufacturer: "a", model: "m", type: "t"),
         library: LibraryContext(name: "l", version: "1"),
         os: OSContext(name: "iOS", version: "1"),
         screen: ScreenContext(density: 2.0, width: 1, height: 1),

--- a/Tests/MetaRouterTests/EventEnrichmentTests.swift
+++ b/Tests/MetaRouterTests/EventEnrichmentTests.swift
@@ -291,7 +291,6 @@ final class MockContextProvider: ContextProvider, @unchecked Sendable {
             device: DeviceContext(
                 manufacturer: "Apple",
                 model: "iPhone15,2",
-                name: "Test Device",
                 type: "ios"
             ),
             library: LibraryContext(

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -441,7 +441,7 @@ final class PersistentEventQueueTests: XCTestCase {
 private func makeTestEvent(messageId: String = "mid", timestamp: String = "now") -> EnrichedEventPayload {
     let ctx = EventContext(
         app: AppContext(name: "a", version: "1", build: "1", namespace: "a"),
-        device: DeviceContext(manufacturer: "a", model: "m", name: "n", type: "t"),
+        device: DeviceContext(manufacturer: "a", model: "m", type: "t"),
         library: LibraryContext(name: "l", version: "1"),
         os: OSContext(name: "iOS", version: "1"),
         screen: ScreenContext(density: 2.0, width: 1, height: 1),

--- a/Tests/MetaRouterTests/QueueSnapshotTests.swift
+++ b/Tests/MetaRouterTests/QueueSnapshotTests.swift
@@ -65,7 +65,7 @@ final class QueueSnapshotTests: XCTestCase {
 private func makeTestEvent(messageId: String = "mid") -> EnrichedEventPayload {
     let ctx = EventContext(
         app: AppContext(name: "a", version: "1", build: "1", namespace: "a"),
-        device: DeviceContext(manufacturer: "a", model: "m", name: "n", type: "t"),
+        device: DeviceContext(manufacturer: "a", model: "m", type: "t"),
         library: LibraryContext(name: "l", version: "1"),
         os: OSContext(name: "iOS", version: "1"),
         screen: ScreenContext(density: 2.0, width: 1, height: 1),


### PR DESCRIPTION
Aligning device context with Android and removing potential PII device names from context. 

Previously the name was the user's device name and we were maintaining a human readable map for the device model. I'd rather not maintain that and just conform to the os specific values and downstream consumers can do what they want with those values. They are industry standard albeit a bit difficult to parse.

This is coming up as Costco wants to access these values and I want to ensure that these values are uniform across all SDKs.

## Summary
- **`name`** no longer sends `UIDevice.current.name` (PII like "Chris's iPhone") — now sends raw `utsname.machine` hardware code (e.g., `iPhone17,2`), matching Android's `Build.DEVICE`
- **`model`** no longer maps hardware codes to human-friendly names — sends raw `utsname.machine` value, letting downstream consumers handle mapping (same as Android's `Build.MODEL`)
- Removed ~40-line `mapDeviceModel` hardcoded lookup table (was a maintenance burden, incomplete coverage)
- Same changes applied to macOS path (`Host.current().localizedName` → `macHardwareModel()`)

[sc-37609](https://app.shortcut.com/metarouter/story/37609)
