### PR TITLE
feat: debounce_timing [ios]

### DIFF
--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -11,6 +11,7 @@ internal struct AnalyticsDependencies: Sendable {
     var dispatcherConfig: Dispatcher.Config?
     var dispatcher: Dispatcher?
     var persistentQueue: PersistentEventQueue?
+    var networkMonitor: NetworkReachability?
 
     static let production = AnalyticsDependencies()
 }
@@ -23,6 +24,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
     private let identityManager: IdentityManager
     private let enrichmentService: EventEnrichmentService
     private let dispatcher: Dispatcher
+    private let networkMonitor: NetworkReachability
     private var lifecycle: AppLifecycleObserver?
     private var lifecycleState: LifecycleState = .idle
     private var disabled = false
@@ -55,6 +57,10 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             config: deps.dispatcherConfig ?? Dispatcher.Config(endpointPath: "/v1/batch", timeoutMs: 8000, autoFlushThreshold: 20, initialMaxBatchSize: 100)
         )
         
+        let rawMonitor = deps.networkMonitor ?? NetworkMonitor()
+        let monitor = DebouncedNetworkMonitor(inner: rawMonitor)
+        self.networkMonitor = monitor
+
         // Enable debug logging if requested
         if options.debug {
             Logger.setDebugLogging(true)
@@ -67,6 +73,20 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
                 self?.disabled = true
                 self?.lifecycleState = .disabled
             })
+        }
+
+        monitor.onStatusChange { [weak self] status in
+            guard let self else { return }
+            Task { [weak self] in
+                guard let self else { return }
+                if status == .disconnected {
+                    await self.dispatcher.setOffline(true)
+                } else {
+                    await self.dispatcher.resetCircuitBreaker()
+                    await self.dispatcher.setOffline(false)
+                    await self.dispatcher.flush()
+                }
+            }
         }
 
         self.lifecycle = AppLifecycleObserver(
@@ -349,6 +369,9 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             if let deviceProvider = self.contextProvider as? DeviceContextProvider {
                 await deviceProvider.setAdvertisingId(nil)
             }
+
+            // Stop network monitoring
+            self.networkMonitor.stop()
 
             await self.dispatcher.stopFlushLoop()
             await self.dispatcher.cancelScheduledRetry()

--- a/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
+++ b/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Wraps a `NetworkReachability` monitor and debounces online transitions.
+/// Offline transitions fire immediately; online transitions only fire after
+/// connectivity is stable for `debounceSeconds` (default 2s).
+public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Sendable {
+    private let inner: NetworkReachability
+    private let debounceNs: UInt64
+    private let lock = NSLock()
+    private var _currentStatus: NetworkStatus
+    private var handler: (@Sendable (NetworkStatus) -> Void)?
+    private var debounceTask: Task<Void, Never>?
+
+    public var currentStatus: NetworkStatus {
+        lock.withLock { _currentStatus }
+    }
+
+    /// - Parameters:
+    ///   - inner: The underlying network monitor to wrap.
+    ///   - debounceSeconds: How long an online signal must be stable before firing. Default 2s.
+    public init(inner: NetworkReachability, debounceSeconds: TimeInterval = 2.0) {
+        self.inner = inner
+        self.debounceNs = UInt64(debounceSeconds * 1_000_000_000)
+        self._currentStatus = inner.currentStatus
+
+        inner.onStatusChange { [weak self] rawStatus in
+            self?.handleRawStatusChange(rawStatus)
+        }
+    }
+
+    public func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void) {
+        lock.withLock { self.handler = handler }
+    }
+
+    public func stop() {
+        lock.lock()
+        handler = nil
+        let task = debounceTask
+        debounceTask = nil
+        lock.unlock()
+        task?.cancel()
+        inner.stop()
+    }
+
+    private func handleRawStatusChange(_ rawStatus: NetworkStatus) {
+        lock.lock()
+        let oldStatus = _currentStatus
+
+        if rawStatus == .disconnected {
+            // Offline: immediate — cancel any pending online debounce
+            debounceTask?.cancel()
+            debounceTask = nil
+            _currentStatus = .disconnected
+            let callback = handler
+            lock.unlock()
+
+            if oldStatus != .disconnected {
+                Logger.log("Debounced network: immediate offline transition")
+                callback?(.disconnected)
+            }
+        } else {
+            // Online: debounce — wait for stability before firing
+            debounceTask?.cancel()
+            let interval = debounceNs
+            debounceTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: interval)
+                guard !Task.isCancelled else { return }
+                self?.commitOnline()
+            }
+            lock.unlock()
+        }
+    }
+
+    private func commitOnline() {
+        lock.lock()
+        let oldStatus = _currentStatus
+        _currentStatus = .connected
+        let callback = handler
+        lock.unlock()
+
+        if oldStatus != .connected {
+            Logger.log("Debounced network: online transition confirmed after debounce")
+            callback?(.connected)
+        }
+    }
+}

--- a/Sources/MetaRouter/network/Dispatcher.swift
+++ b/Sources/MetaRouter/network/Dispatcher.swift
@@ -38,6 +38,7 @@ public actor Dispatcher {
     private var flushTimerTask: Task<Void, Never>? = nil
     private var retryTimerTask: Task<Void, Never>? = nil
     private var isFlushing = false
+    private var isOffline = false
     private let config: Config
     private var tracingEnabled = false
     private var consecutiveRetries: Int = 0
@@ -86,6 +87,14 @@ public actor Dispatcher {
         self.onFatalConfigError = handler
     }
 
+    public func setOffline(_ offline: Bool) {
+        self.isOffline = offline
+    }
+
+    public func resetCircuitBreaker() {
+        breaker.onSuccess()
+    }
+
     public func setTracing(_ enabled: Bool) {
         self.tracingEnabled = enabled
         Logger.log("Tracing \(enabled ? "enabled" : "disabled")")
@@ -132,6 +141,7 @@ public actor Dispatcher {
 
     public func flush() async {
         guard !isFlushing else { return }
+        guard !isOffline else { return }
         guard await queue.count > 0 else { return }
         isFlushing = true
         defer { isFlushing = false }

--- a/Sources/MetaRouter/network/NetworkMonitor.swift
+++ b/Sources/MetaRouter/network/NetworkMonitor.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Network
+
+/// Monitors network reachability using NWPathMonitor.
+/// Reports connectivity changes via the `onStatusChange` callback.
+public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
+    private let monitor: NWPathMonitor
+    private let queue: DispatchQueue
+    private let lock = NSLock()
+    private var _currentStatus: NetworkStatus
+    private var handler: (@Sendable (NetworkStatus) -> Void)?
+
+    public var currentStatus: NetworkStatus {
+        lock.withLock { _currentStatus }
+    }
+
+    public init() {
+        self.monitor = NWPathMonitor()
+        self.queue = DispatchQueue(label: "com.metarouter.network-monitor")
+        self._currentStatus = .disconnected
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            let newStatus: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
+
+            self.lock.lock()
+            let oldStatus = self._currentStatus
+            self._currentStatus = newStatus
+            let callback = self.handler
+            self.lock.unlock()
+
+            if newStatus != oldStatus {
+                Logger.log("Network status changed: \(newStatus)")
+                callback?(newStatus)
+            }
+        }
+
+        monitor.start(queue: queue)
+    }
+
+    public func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void) {
+        lock.withLock { self.handler = handler }
+    }
+
+    public func stop() {
+        lock.lock()
+        handler = nil
+        lock.unlock()
+        monitor.cancel()
+    }
+}

--- a/Sources/MetaRouter/network/NetworkReachability.swift
+++ b/Sources/MetaRouter/network/NetworkReachability.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Represents the current network connectivity status.
+public enum NetworkStatus: Sendable, Equatable {
+    case connected
+    case disconnected
+}
+
+/// Protocol for network reachability monitoring.
+/// Implementations report connectivity changes and expose current status.
+public protocol NetworkReachability: AnyObject, Sendable {
+    var currentStatus: NetworkStatus { get }
+    func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void)
+    func stop()
+}

--- a/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
+++ b/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
@@ -1,0 +1,288 @@
+import XCTest
+@testable import MetaRouter
+
+
+// MARK: - Test Doubles
+
+/// Stub network monitor for testing. Allows simulating status changes synchronously.
+final class StubNetworkMonitor: NetworkReachability, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _currentStatus: NetworkStatus
+    private var handler: (@Sendable (NetworkStatus) -> Void)?
+
+    var currentStatus: NetworkStatus {
+        lock.withLock { _currentStatus }
+    }
+
+    init(status: NetworkStatus) {
+        self._currentStatus = status
+    }
+
+    func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void) {
+        lock.withLock { self.handler = handler }
+    }
+
+    func stop() {
+        lock.withLock { handler = nil }
+    }
+
+    /// Simulate a network status change (fires handler synchronously).
+    func simulate(_ status: NetworkStatus) {
+        lock.lock()
+        _currentStatus = status
+        let callback = handler
+        lock.unlock()
+        callback?(status)
+    }
+}
+
+
+// MARK: - Helpers
+
+private final class StatusRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _statuses: [NetworkStatus] = []
+    var statuses: [NetworkStatus] { lock.withLock { _statuses } }
+    func append(_ status: NetworkStatus) { lock.withLock { _statuses.append(status) } }
+}
+
+
+// MARK: - Tests
+
+final class DebouncedNetworkMonitorTests: XCTestCase {
+
+    // MARK: Task 1 — Offline transitions are immediate
+
+    func testOfflineTransitionIsImmediate() {
+        let stub = StubNetworkMonitor(status: .connected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.1)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        stub.simulate(.disconnected)
+
+        XCTAssertEqual(recorder.statuses, [.disconnected])
+        XCTAssertEqual(debounced.currentStatus, .disconnected)
+    }
+
+    // MARK: Task 2 — Online transitions are debounced
+
+    func testOnlineTransitionIsDebounced() async {
+        let stub = StubNetworkMonitor(status: .disconnected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.2)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        stub.simulate(.connected)
+
+        XCTAssertEqual(recorder.statuses, [], "Online should not fire before debounce interval")
+        XCTAssertEqual(debounced.currentStatus, .disconnected, "currentStatus should not change before debounce")
+
+        try? await Task.sleep(nanoseconds: 350_000_000) // 350ms > 200ms debounce
+
+        XCTAssertEqual(recorder.statuses, [.connected], "Online should fire after debounce interval")
+        XCTAssertEqual(debounced.currentStatus, .connected)
+    }
+
+    // MARK: Task 3 — Rapid flapping produces single offline
+
+    func testRapidFlappingProducesNoOnlineTransition() async {
+        let stub = StubNetworkMonitor(status: .connected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.2)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        // Rapid flap: offline → online → offline → online → offline
+        stub.simulate(.disconnected)
+        stub.simulate(.connected)
+        stub.simulate(.disconnected)
+        stub.simulate(.connected)
+        stub.simulate(.disconnected)
+
+        XCTAssertEqual(recorder.statuses, [.disconnected],
+            "Rapid flapping should produce single offline, no online")
+
+        try? await Task.sleep(nanoseconds: 350_000_000)
+
+        XCTAssertEqual(recorder.statuses, [.disconnected],
+            "No delayed online should fire after flapping ends disconnected")
+        XCTAssertEqual(debounced.currentStatus, .disconnected)
+    }
+
+    // MARK: Task 4 — Debounce timer cancelled on re-disconnect
+
+    func testDebounceTimerCancelledOnReDisconnect() async {
+        let stub = StubNetworkMonitor(status: .disconnected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.2)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        stub.simulate(.connected)
+        XCTAssertEqual(recorder.statuses, [], "Online should not fire immediately")
+
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms < 200ms debounce
+        stub.simulate(.disconnected)
+
+        try? await Task.sleep(nanoseconds: 300_000_000) // 300ms total > 200ms debounce
+
+        XCTAssertEqual(recorder.statuses, [],
+            "No transitions should fire: online was cancelled, offline was idempotent")
+        XCTAssertEqual(debounced.currentStatus, .disconnected)
+    }
+
+    // MARK: Task 5 — Clean transitions work normally
+
+    func testCleanTransitionsWorkNormally() async {
+        let stub = StubNetworkMonitor(status: .connected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.1)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        // Clean offline
+        stub.simulate(.disconnected)
+        XCTAssertEqual(recorder.statuses, [.disconnected])
+
+        // Clean online — wait for debounce
+        stub.simulate(.connected)
+        try? await Task.sleep(nanoseconds: 200_000_000) // 200ms > 100ms debounce
+        XCTAssertEqual(recorder.statuses, [.disconnected, .connected])
+
+        // Another clean offline
+        stub.simulate(.disconnected)
+        XCTAssertEqual(recorder.statuses, [.disconnected, .connected, .disconnected])
+
+        XCTAssertEqual(debounced.currentStatus, .disconnected)
+    }
+
+    // MARK: Task 6 — Stop cancels debounce and cleans up
+
+    func testStopCancelsDebounceAndCleansUp() async {
+        let stub = StubNetworkMonitor(status: .disconnected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.2)
+
+        let recorder = StatusRecorder()
+        debounced.onStatusChange { status in recorder.append(status) }
+
+        stub.simulate(.connected)
+
+        debounced.stop()
+
+        try? await Task.sleep(nanoseconds: 350_000_000)
+
+        XCTAssertEqual(recorder.statuses, [],
+            "No transitions should fire after stop()")
+    }
+
+    func testCurrentStatusReflectsInitialInnerStatus() {
+        let connectedStub = StubNetworkMonitor(status: .connected)
+        let debouncedConnected = DebouncedNetworkMonitor(inner: connectedStub, debounceSeconds: 0.1)
+        XCTAssertEqual(debouncedConnected.currentStatus, .connected)
+
+        let disconnectedStub = StubNetworkMonitor(status: .disconnected)
+        let debouncedDisconnected = DebouncedNetworkMonitor(inner: disconnectedStub, debounceSeconds: 0.1)
+        XCTAssertEqual(debouncedDisconnected.currentStatus, .disconnected)
+    }
+
+    // MARK: Task 8 — Integration: rapid flapping produces single flush
+
+    func testRapidFlappingProducesSingleFlushThroughDispatcher() async {
+        let stub = StubNetworkMonitor(status: .connected)
+        let debounced = DebouncedNetworkMonitor(inner: stub, debounceSeconds: 0.2)
+
+        let flushCounter = FlushCounter()
+        let options = TestDataFactory.makeInitOptions()
+        let networking = CountingNetworking(counter: flushCounter)
+        let dispatcher = Dispatcher(
+            options: options,
+            http: networking,
+            breaker: CircuitBreaker(),
+            queueCapacity: 100
+        )
+
+        // Enqueue an event
+        await dispatcher.offer(makeTestEvent())
+
+        // Wire debounced monitor to dispatcher
+        debounced.onStatusChange { status in
+            Task {
+                if status == .disconnected {
+                    await dispatcher.setOffline(true)
+                } else {
+                    await dispatcher.resetCircuitBreaker()
+                    await dispatcher.setOffline(false)
+                    await dispatcher.flush()
+                }
+            }
+        }
+
+        // Go offline first
+        await dispatcher.setOffline(true)
+
+        // Rapid flap: online → offline → online → offline → online (ends connected)
+        stub.simulate(.connected)
+        stub.simulate(.disconnected)
+        stub.simulate(.connected)
+        stub.simulate(.disconnected)
+        stub.simulate(.connected)
+
+        // No flush should have happened yet
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        XCTAssertEqual(flushCounter.value, 0, "No flush during flapping")
+
+        // Wait for debounce to complete
+        try? await Task.sleep(nanoseconds: 300_000_000) // 350ms total > 200ms debounce
+
+        // Give the flush Task time to execute
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(flushCounter.value, 1, "Exactly one flush after stable reconnect")
+    }
+}
+
+
+// MARK: - Integration Test Helpers
+
+private final class FlushCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int { lock.withLock { _value } }
+    func increment() { lock.withLock { _value += 1 } }
+}
+
+private final class CountingNetworking: Networking, @unchecked Sendable {
+    private let counter: FlushCounter
+
+    init(counter: FlushCounter) {
+        self.counter = counter
+    }
+
+    func postJSON(url: URL, body: Data, timeoutMs: Int, additionalHeaders: [String: String]?) async throws -> NetworkResponse {
+        counter.increment()
+        return NetworkResponse(statusCode: 200, headers: [:], body: Data())
+    }
+
+    func parseRetryAfterMs(from headers: [String: String]) -> Int? { nil }
+}
+
+private func makeTestEvent(messageId: String = "mid") -> EnrichedEventPayload {
+    let ctx = EventContext(
+        app: AppContext(name: "a", version: "1", build: "1", namespace: "a"),
+        device: DeviceContext(manufacturer: "a", model: "m", type: "t"),
+        library: LibraryContext(name: "l", version: "1"),
+        os: OSContext(name: "iOS", version: "1"),
+        screen: ScreenContext(density: 2.0, width: 1, height: 1),
+        network: nil,
+        locale: "en_US",
+        timezone: "UTC"
+    )
+    return EnrichedEventPayload(
+        type: "track", event: "ev", userId: nil, anonymousId: "anon",
+        properties: nil, traits: nil, integrations: nil,
+        timestamp: "now", writeKey: "wk", messageId: messageId, context: ctx
+    )
+}


### PR DESCRIPTION
## Summary

Adds network reachability debouncing to the iOS SDK. Online transitions are debounced by 2 seconds for stability; offline transitions fire immediately.

**Ticket:** SC-37712

### What changed
- **New:** `NetworkReachability` protocol + `NetworkStatus` enum — abstraction for network monitoring
- **New:** `NetworkMonitor` — `NWPathMonitor` wrapper implementing `NetworkReachability`
- **New:** `DebouncedNetworkMonitor` — wrapper that debounces online transitions (2s default), fires offline immediately, cancels pending debounce on re-disconnect
- **Modified:** `Dispatcher` — added `setOffline()` (gates flush when offline) and `resetCircuitBreaker()` (exposes breaker reset for reconnect)
- **Modified:** `AnalyticsClient` — wires `DebouncedNetworkMonitor` around the network monitor; status changes drive `dispatcher.setOffline` + `resetCircuitBreaker` + `flush` on stable reconnect

### Why
Prevents circuit breaker reset, wasteful flush attempts, and dispatcher churn during rapid network flapping (e.g., transitioning between WiFi and cellular). Aligns with Android and React Native SDK debounce behavior.

### Cross-platform alignment
| Aspect | iOS | Android | React Native |
|--------|-----|---------|--------------|
| Online debounce | 2s | 2s | 2s |
| Offline behavior | Immediate | Immediate | Immediate |
| Debounce location | `DebouncedNetworkMonitor` wrapper | `DebouncedNetworkHandler` class | Inline in client callback |
| Monitor unchanged | Yes | Yes | Yes |

## Test plan
- [x] `testOfflineTransitionIsImmediate` — offline fires synchronously, no delay
- [x] `testOnlineTransitionIsDebounced` — online waits 200ms (test interval) before firing
- [x] `testRapidFlappingProducesNoOnlineTransition` — rapid off/on/off/on/off → single offline, zero online
- [x] `testDebounceTimerCancelledOnReDisconnect` — online debounce cancelled when device goes back offline
- [x] `testCleanTransitionsWorkNormally` — sequential offline → online → offline with gaps works correctly
- [x] `testStopCancelsDebounceAndCleansUp` — `stop()` cancels pending debounce timer
- [x] `testCurrentStatusReflectsInitialInnerStatus` — initial status matches inner monitor
- [x] `testRapidFlappingProducesSingleFlushThroughDispatcher` — integration: rapid flapping → exactly 1 flush after stable reconnect
- [x] Full test suite: 360 tests, 0 failures


🤖 Generated with [Claude Code](https://claude.com/claude-code)