### PR TITLE
feat: network-awarness

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ Calls to `track`, `identify`, etc. are **buffered in-memory** by the proxy and r
 - `writeKey` (String, required): Your write key
 - `ingestionHost` (String or URL, required): Your MetaRouter ingestor host
 - `debug` (Bool, optional): Enable debug mode
-- `flushIntervalSeconds` (Int, optional): Interval in seconds to flush events
-- `maxQueueEvents` (Int, optional): Number of max events stored in memory
+- `flushIntervalSeconds` (Int, optional): Interval in seconds to flush events (default `10`)
+- `maxQueueEvents` (Int, optional): Maximum events buffered in the in-memory queue (default `2000`, must be > 0)
+- `maxDiskEvents` (Int, optional): Maximum events retained on disk across crash-safety snapshots and extended-offline overflow (default `10000`). Set to `0` to **disable disk persistence entirely** — the SDK then runs as a purely in-memory pipeline (oldest events dropped when memory is full; nothing recovered across app launches).
 
 **Proxy behavior (quick notes):**
 
@@ -611,6 +612,12 @@ Unsent events are automatically persisted to disk and recovered across app launc
 - Excluded from iCloud backup
 - Atomic writes (no partial corruption)
 - Resilient decoding: individual corrupt events are skipped rather than losing the entire snapshot
+
+**Disk cap (`maxDiskEvents`):**
+
+- Default `10000`. When the cap is exceeded, the oldest events on disk are dropped first (FIFO).
+- Set `maxDiskEvents: 0` to **disable disk persistence entirely**. The SDK then runs as a purely in-memory pipeline — no background flush to disk, no overflow writes, and no recovery across app launches. Memory-queue eviction (`maxQueueEvents` cap) drops the oldest events when the queue is full.
+- Disabling persistence is appropriate for apps that never want events to survive a process restart (e.g. strict privacy requirements or short-lived sessions). In all other cases, the default is recommended.
 
 **`sentAt` semantics:** `sentAt` is stamped when a batch is prepared for transmission (just before network send), not when the event was originally created. Events rehydrated from disk receive a fresh `sentAt` on their next send attempt. If you need the original occurrence time, rely on the `timestamp` field set at event creation.
 

--- a/README.md
+++ b/README.md
@@ -616,7 +616,13 @@ Unsent events are automatically persisted to disk and recovered across app launc
 **Disk cap (`maxDiskEvents`):**
 
 - Default `10000`. When the cap is exceeded, the oldest events on disk are dropped first (FIFO).
-- Set `maxDiskEvents: 0` to **disable disk persistence entirely**. The SDK then runs as a purely in-memory pipeline — no background flush to disk, no overflow writes, and no recovery across app launches. Memory-queue eviction (`maxQueueEvents` cap) drops the oldest events when the queue is full.
+- Negative values are rejected.
+- Set `maxDiskEvents: 0` to **disable disk persistence entirely**. The SDK then runs as a purely in-memory pipeline:
+  - No background flush to disk (events in memory at app-background or app-kill are **lost**)
+  - No overflow writes while offline (memory cap is the only buffer)
+  - No recovery across app launches
+  - `maxQueueEvents` still applies — when the in-memory queue is full, the oldest event is dropped to make room (ring buffer)
+  - On retry-after-failure, requeued events are inserted at the front; if that overflows the cap, the **newest** entries are dropped from the back so the retry events survive
 - Disabling persistence is appropriate for apps that never want events to survive a process restart (e.g. strict privacy requirements or short-lived sessions). In all other cases, the default is recommended.
 
 **`sentAt` semantics:** `sentAt` is stamped when a batch is prepared for transmission (just before network send), not when the event was originally created. Events rehydrated from disk receive a fresh `sentAt` on their next send attempt. If you need the original occurrence time, rely on the `timestamp` field set at event creation.

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -44,15 +44,11 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             writeKey: options.writeKey
         )
 
-        let mainDiskStorage = DiskStorage()
+        let diskStore = DiskStorage()
         let persistentQueue = deps.persistentQueue ?? PersistentEventQueue(
-            diskStorage: mainDiskStorage,
+            diskStore: diskStore,
             maxEventCount: options.maxQueueEvents,
-            overflowDiskStorage: DiskStorage(
-                baseDirectory: mainDiskStorage.baseDirectory,
-                fileName: "overflow.v1.json"
-            ),
-            maxOfflineDiskEvents: options.maxOfflineDiskEvents
+            maxDiskEvents: options.maxDiskEvents
         )
 
         self.dispatcher = deps.dispatcher ?? Dispatcher(
@@ -80,10 +76,10 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
                 self?.disabled = true
                 self?.lifecycleState = .disabled
             })
-            // Wire onFlushComplete to trigger overflow drain when online
+            // Wire onFlushComplete to trigger disk drain when online
             await self.dispatcher.setFlushCompleteHandler({ [weak self] in
                 guard let self else { return }
-                await self.dispatcher.drainOverflowToNetwork()
+                await self.dispatcher.drainDiskStoreToNetwork()
             })
         }
 
@@ -99,7 +95,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             onBackgroundAsync: { [weak self] in
                 guard let self else { return }
                 await self.dispatcher.flush()
-                try? await self.dispatcher.flushToDisk()
+                await self.dispatcher.flushToDisk()
                 await self.dispatcher.stopFlushLoop()
                 await self.dispatcher.cancelScheduledRetry()
             }
@@ -120,14 +116,27 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             }
         }
 
+        // Periodic network reconciliation — only active while the dispatcher thinks
+        // we're offline. Catches transitions that NWPathMonitor's pathUpdateHandler
+        // misses (known issue on simulator, rare edge cases on device).
+        Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000_000) // 10s
+                guard let self else { return }
+                guard await self.dispatcher.getIsOffline() else { continue }
+                monitor.reconcile()
+            }
+        }
+
         Task { [weak self] in
             guard let self else { return }
             await self.identityManager.initialize()
 
-            // Rehydrate persisted events from disk
-            let rehydratedCount = await self.dispatcher.rehydrate()
-            if rehydratedCount > 0 {
-                Logger.log("Rehydrated \(rehydratedCount) events from disk",
+            // Check disk for persisted events (cheap existence check, no parse).
+            // Actual drain happens below once we confirm we're online.
+            let hasPersisted = await self.dispatcher.checkForPersistedEvents()
+            if hasPersisted {
+                Logger.log("Persisted events detected on disk — will drain once online",
                            writeKey: self.options.writeKey,
                            host: self.options.ingestionHost.absoluteString)
             }
@@ -148,9 +157,9 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
                        writeKey: self.options.writeKey,
                        host: self.options.ingestionHost.absoluteString)
 
-            // Drain any overflow from a previous offline session
+            // Drain any persisted events from a previous session
             if monitor.currentStatus == .connected {
-                await self.dispatcher.drainOverflowToNetwork()
+                await self.dispatcher.drainDiskStoreToNetwork()
             }
         }
     }

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -80,6 +80,11 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
                 self?.disabled = true
                 self?.lifecycleState = .disabled
             })
+            // Wire onFlushComplete to trigger overflow drain when online
+            await self.dispatcher.setFlushCompleteHandler({ [weak self] in
+                guard let self else { return }
+                await self.dispatcher.drainOverflowToNetwork()
+            })
         }
 
         self.lifecycle = AppLifecycleObserver(

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -44,9 +44,15 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             writeKey: options.writeKey
         )
 
+        let mainDiskStorage = DiskStorage()
         let persistentQueue = deps.persistentQueue ?? PersistentEventQueue(
-            diskStorage: DiskStorage(),
-            maxEventCount: options.maxQueueEvents
+            diskStorage: mainDiskStorage,
+            maxEventCount: options.maxQueueEvents,
+            overflowDiskStorage: DiskStorage(
+                baseDirectory: mainDiskStorage.baseDirectory,
+                fileName: "overflow.v1.json"
+            ),
+            maxOfflineDiskEvents: options.maxOfflineDiskEvents
         )
 
         self.dispatcher = deps.dispatcher ?? Dispatcher(
@@ -136,6 +142,11 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             Logger.log("MetaRouter SDK initialized",
                        writeKey: self.options.writeKey,
                        host: self.options.ingestionHost.absoluteString)
+
+            // Drain any overflow from a previous offline session
+            if monitor.currentStatus == .connected {
+                await self.dispatcher.drainOverflowToNetwork()
+            }
         }
     }
 

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -117,18 +117,6 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             }
         }
 
-        // Periodic network reconciliation — only active while the dispatcher thinks
-        // we're offline. Catches transitions that NWPathMonitor's pathUpdateHandler
-        // misses (known issue on simulator, rare edge cases on device).
-        Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 10_000_000_000) // 10s
-                guard let self else { return }
-                guard await self.dispatcher.getIsOffline() else { continue }
-                monitor.reconcile()
-            }
-        }
-
         self.initTask = Task { [weak self] in
             guard let self else { return }
             await self.identityManager.initialize()

--- a/Sources/MetaRouter/analytics/InitOptions.swift
+++ b/Sources/MetaRouter/analytics/InitOptions.swift
@@ -28,6 +28,10 @@ public struct InitOptions: Sendable {
         self.debug = debug
         self.maxQueueEvents = max(1, maxQueueEvents)
         self.maxDiskEvents = max(0, maxDiskEvents)
+
+        if self.maxDiskEvents > 0 && self.maxDiskEvents < self.maxQueueEvents {
+            Logger.warn("maxDiskEvents (\(self.maxDiskEvents)) is less than maxQueueEvents (\(self.maxQueueEvents)) — memory can hold more events than disk can preserve; events may be dropped during background flush")
+        }
     }
 }
 

--- a/Sources/MetaRouter/analytics/InitOptions.swift
+++ b/Sources/MetaRouter/analytics/InitOptions.swift
@@ -22,12 +22,14 @@ public struct InitOptions: Sendable {
         let raw = ingestionHost.absoluteString
         precondition(!raw.hasSuffix("/"), "ingestionHost must not end with a slash")
 
+        precondition(maxDiskEvents >= 0, "maxDiskEvents must be >= 0 (use 0 to disable disk persistence)")
+
         self.writeKey = writeKey
         self.ingestionHost = ingestionHost
         self.flushIntervalSeconds = max(1, flushIntervalSeconds)
         self.debug = debug
         self.maxQueueEvents = max(1, maxQueueEvents)
-        self.maxDiskEvents = max(0, maxDiskEvents)
+        self.maxDiskEvents = maxDiskEvents
 
         if self.maxDiskEvents > 0 && self.maxDiskEvents < self.maxQueueEvents {
             Logger.warn("maxDiskEvents (\(self.maxDiskEvents)) is less than maxQueueEvents (\(self.maxQueueEvents)) — memory can hold more events than disk can preserve; events may be dropped during background flush")

--- a/Sources/MetaRouter/analytics/InitOptions.swift
+++ b/Sources/MetaRouter/analytics/InitOptions.swift
@@ -6,7 +6,7 @@ public struct InitOptions: Sendable {
     public let flushIntervalSeconds: Int
     public let debug: Bool
     public let maxQueueEvents: Int
-    public let maxOfflineDiskEvents: Int
+    public let maxDiskEvents: Int
 
     public init(
         writeKey: String,
@@ -14,7 +14,7 @@ public struct InitOptions: Sendable {
         flushIntervalSeconds: Int = 10,
         debug: Bool = false,
         maxQueueEvents: Int = 2000,
-        maxOfflineDiskEvents: Int = 10000
+        maxDiskEvents: Int = 10000
     ) {
         precondition(!writeKey.isEmpty, "writeKey must not be empty")
 
@@ -27,7 +27,7 @@ public struct InitOptions: Sendable {
         self.flushIntervalSeconds = max(1, flushIntervalSeconds)
         self.debug = debug
         self.maxQueueEvents = max(1, maxQueueEvents)
-        self.maxOfflineDiskEvents = max(0, maxOfflineDiskEvents)
+        self.maxDiskEvents = max(0, maxDiskEvents)
     }
 }
 
@@ -38,7 +38,7 @@ extension InitOptions {
         flushIntervalSeconds: Int = 10,
         debug: Bool = false,
         maxQueueEvents: Int = 2000,
-        maxOfflineDiskEvents: Int = 10000
+        maxDiskEvents: Int = 10000
     ) {
         var host = ingestionHost.trimmingCharacters(in: .whitespacesAndNewlines)
         if host.hasSuffix("/") {
@@ -53,7 +53,7 @@ extension InitOptions {
             flushIntervalSeconds: flushIntervalSeconds,
             debug: debug,
             maxQueueEvents: maxQueueEvents,
-            maxOfflineDiskEvents: maxOfflineDiskEvents
+            maxDiskEvents: maxDiskEvents
         )
     }
 }

--- a/Sources/MetaRouter/enrichment/EventEnrichment.swift
+++ b/Sources/MetaRouter/enrichment/EventEnrichment.swift
@@ -3,8 +3,6 @@ import Foundation
 /// Service responsible for enriching events with context and metadata
 public final class EventEnrichmentService: Sendable {
 
-    nonisolated(unsafe) private static let isoFormatter = ISO8601DateFormatter()
-
     private let contextProvider: ContextProvider
     private let identityManager: IdentityManager
     private let writeKey: String
@@ -44,7 +42,7 @@ public final class EventEnrichmentService: Sendable {
         _ baseEvent: BaseEvent
     ) async -> EnrichedEventPayload {
         let identity = await identityManager.getIdentityInfo()
-        let timestamp = baseEvent.timestamp ?? Self.isoFormatter.string(from: Date())
+        let timestamp = baseEvent.timestamp ?? DateFormatters.iso8601.string(from: Date())
 
         let eventWithIdentity = EventWithIdentity(
             type: baseEvent.type,

--- a/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
+++ b/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
@@ -42,13 +42,6 @@ public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Send
         inner.stop()
     }
 
-    /// Delegate reconciliation to the inner monitor.
-    /// If the inner monitor detects a drifted status, its callback flows through
-    /// our handleRawStatusChange which applies the normal debounce logic.
-    public func reconcile() {
-        inner.reconcile()
-    }
-
     private func handleRawStatusChange(_ rawStatus: NetworkStatus) {
         lock.lock()
         let oldStatus = _currentStatus
@@ -62,20 +55,15 @@ public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Send
             lock.unlock()
 
             if oldStatus != .disconnected {
-                Logger.log("Debounced network: immediate offline transition")
                 callback?(.disconnected)
             }
         } else {
             // Online: debounce — wait for stability before firing
-            Logger.log("Debounced network: raw online signal received (current=\(oldStatus.rawValue)), starting \(debounceNs / 1_000_000_000)s debounce")
             debounceTask?.cancel()
             let interval = debounceNs
             debounceTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: interval)
-                guard !Task.isCancelled else {
-                    Logger.log("Debounced network: online debounce cancelled (flapping?)")
-                    return
-                }
+                guard !Task.isCancelled else { return }
                 self?.commitOnline()
             }
             lock.unlock()
@@ -90,7 +78,6 @@ public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Send
         lock.unlock()
 
         if oldStatus != .connected {
-            Logger.log("Debounced network: online transition confirmed after debounce")
             callback?(.connected)
         }
     }

--- a/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
+++ b/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
@@ -60,11 +60,15 @@ public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Send
             }
         } else {
             // Online: debounce — wait for stability before firing
+            Logger.log("Debounced network: raw online signal received (current=\(oldStatus.rawValue)), starting \(debounceNs / 1_000_000_000)s debounce")
             debounceTask?.cancel()
             let interval = debounceNs
             debounceTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: interval)
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else {
+                    Logger.log("Debounced network: online debounce cancelled (flapping?)")
+                    return
+                }
                 self?.commitOnline()
             }
             lock.unlock()

--- a/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
+++ b/Sources/MetaRouter/network/DebouncedNetworkMonitor.swift
@@ -42,6 +42,13 @@ public final class DebouncedNetworkMonitor: NetworkReachability, @unchecked Send
         inner.stop()
     }
 
+    /// Delegate reconciliation to the inner monitor.
+    /// If the inner monitor detects a drifted status, its callback flows through
+    /// our handleRawStatusChange which applies the normal debounce logic.
+    public func reconcile() {
+        inner.reconcile()
+    }
+
     private func handleRawStatusChange(_ rawStatus: NetworkStatus) {
         lock.lock()
         let oldStatus = _currentStatus

--- a/Sources/MetaRouter/network/Dispatcher.swift
+++ b/Sources/MetaRouter/network/Dispatcher.swift
@@ -99,7 +99,7 @@ public actor Dispatcher {
         self.http = http
         self.breaker = breaker
         self.queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: FileManager.default.temporaryDirectory
+            diskStore: DiskStorage(baseDirectory: FileManager.default.temporaryDirectory
                 .appendingPathComponent("metarouter-noop-\(UUID().uuidString)")),
             maxEventCount: queueCapacity
         )
@@ -140,9 +140,9 @@ public actor Dispatcher {
             Logger.log("Dispatcher resumed — device is online, triggering flush")
             // Two independent flush paths:
             await flush() // (1) memory queue → network
-            // (2) disk overflow → network directly (background)
+            // (2) disk store → network directly (background)
             Task { [weak self] in
-                await self?.drainOverflowToNetwork()
+                await self?.drainDiskStoreToNetwork()
             }
         }
     }
@@ -165,11 +165,9 @@ public actor Dispatcher {
 
         // Check disk flush threshold
         if await queue.needsFlushToDisk {
-            do {
-                try await queue.flushToDisk()
+            let flushed = await queue.flushMemoryToDisk()
+            if flushed {
                 Logger.log("Auto disk flush triggered (threshold reached)")
-            } catch {
-                Logger.warn("Auto disk flush failed: \(error)")
             }
         }
 
@@ -178,15 +176,16 @@ public actor Dispatcher {
         }
     }
 
-    /// Flush current memory state to disk.
-    public func flushToDisk() async throws {
-        try await queue.flushToDisk()
+    /// Flush current memory state to disk (append + clear memory).
+    public func flushToDisk() async {
+        await queue.flushMemoryToDisk()
     }
 
-    /// Rehydrate events from disk. Returns the number of events loaded.
+    /// Cheap boot-time check — does the disk store have anything to drain?
+    /// Does not parse the file.
     @discardableResult
-    public func rehydrate() async -> Int {
-        await queue.rehydrate()
+    public func checkForPersistedEvents() async -> Bool {
+        await queue.checkForPersistedEvents()
     }
 
     public func flush() async {
@@ -290,77 +289,112 @@ public actor Dispatcher {
         }
     }
 
-    /// Drain overflow events from disk directly to network in batches.
+    /// Drain events from the disk store directly to network in batches.
     /// Called on offline→online transition, after successful flush, or at startup.
     /// Does NOT load events into the memory queue.
     ///
+    /// Algorithm (O(n) — one read, one delete, iterate in memory):
+    /// 1. Acquire the disk lock so mid-drain memory flushes don't clobber our writes.
+    /// 2. Read the entire disk file once and delete it.
+    /// 3. Iterate batches in memory; checkpoint remaining every 10 successful batches.
+    /// 4. On failure / server error / offline-transition, write remainder back to disk.
+    ///
     /// Response handling per category:
-    /// - SUCCESS: remove batch, restore batch size, continue
+    /// - SUCCESS: drop batch, restore batch size, continue
     /// - PAYLOAD_TOO_LARGE (413): halve batch size, retry. Drop at batchSize=1
-    /// - SERVER_ERROR / RATE_LIMITED (5xx/408/429): stop, retry on next online transition
-    /// - FATAL_CONFIG (401/403/404): delete overflow store entirely
+    /// - SERVER_ERROR / RATE_LIMITED (5xx/408/429): persist remainder, stop
+    /// - FATAL_CONFIG (401/403/404): delete disk store entirely, fire fatal handler
     /// - CLIENT_ERROR (other 4xx): drop batch, continue
-    /// - Network failure (nil): stop, retry on next online transition
-    public func drainOverflowToNetwork() async {
+    /// - Network failure (nil): persist remainder, stop
+    public func drainDiskStoreToNetwork() async {
         guard !isDraining else { return }
         isDraining = true
         defer { isDraining = false }
 
-        var drainBatchSize = config.initialMaxBatchSize
+        guard await queue.hasDiskData else { return }
+        guard !isOffline else {
+            Logger.log("Drain skipped — device is offline")
+            return
+        }
 
-        drainLoop: while !isOffline {
-            let batch = await queue.readOverflowBatch(max: drainBatchSize)
-            guard !batch.isEmpty else { break drainLoop }
+        await queue.acquireDiskLock()
+        defer { Task { await queue.releaseDiskLock() } }
+
+        let all = await queue.readAllFromDiskAndDelete()
+        guard !all.isEmpty else { return }
+
+        var remaining = all
+        var drainBatchSize = config.initialMaxBatchSize
+        var batchesSinceCheckpoint = 0
+        let checkpointEvery = 10
+        Logger.log("Disk store drain started — \(remaining.count) event(s)")
+
+        while !remaining.isEmpty && !isOffline {
+            let take = min(drainBatchSize, remaining.count)
+            let batch = Array(remaining.prefix(take))
 
             guard let resp = await sendBatchDirect(batch) else {
-                Logger.warn("Overflow drain stopped (network failure) — will retry on next online transition")
-                break drainLoop
+                Logger.warn("Disk drain stopped (network failure) — persisting \(remaining.count) event(s) back to disk")
+                await queue.writeDiskStore(remaining)
+                return
             }
 
-            let category = ResponseCategory.from(resp.statusCode)
-            switch category {
+            switch ResponseCategory.from(resp.statusCode) {
             case .success:
-                await queue.removeOverflowBatch(count: batch.count)
-                Logger.log("Drained \(batch.count) overflow events from disk to network")
-                // Gradually recover batch size after 413-induced reduction
+                remaining.removeFirst(take)
                 if drainBatchSize < config.initialMaxBatchSize {
                     drainBatchSize = min(drainBatchSize * 2, config.initialMaxBatchSize)
+                }
+                batchesSinceCheckpoint += 1
+                if batchesSinceCheckpoint >= checkpointEvery && !remaining.isEmpty {
+                    await queue.writeDiskStore(remaining)
+                    batchesSinceCheckpoint = 0
+                    Logger.log("Disk drain checkpoint — \(remaining.count) event(s) remaining")
                 }
 
             case .payloadTooLarge:
                 if drainBatchSize > 1 {
                     drainBatchSize = max(1, drainBatchSize / 2)
-                    Logger.warn("Overflow drain 413 — halving batch size to \(drainBatchSize)")
+                    Logger.warn("Disk drain 413 — halving batch size to \(drainBatchSize)")
                 } else {
-                    // Drop at batchSize=1 — single event is too large
                     let ids = batch.map { $0.messageId }.joined(separator: ",")
-                    Logger.warn("Overflow drain dropping oversize event(s) at batchSize=1; messageIds=\(ids)")
-                    await queue.removeOverflowBatch(count: batch.count)
+                    Logger.warn("Disk drain dropping oversize event(s) at batchSize=1; messageIds=\(ids)")
+                    remaining.removeFirst(take)
                 }
 
             case .serverError, .rateLimited:
-                Logger.warn("Overflow drain stopped (\(resp.statusCode)) — will retry on next online transition")
-                break drainLoop
+                Logger.warn("Disk drain stopped (\(resp.statusCode)) — persisting \(remaining.count) event(s) back to disk")
+                await queue.writeDiskStore(remaining)
+                return
 
             case .fatalConfig:
-                Logger.error("Overflow drain fatal config error (\(resp.statusCode)) — deleting overflow store")
-                await queue.deleteOverflowDisk()
+                Logger.error("Disk drain fatal config error (\(resp.statusCode)) — deleting disk store")
+                await queue.deleteDiskStore()
                 onFatalConfigError?(resp.statusCode)
                 return
 
             case .clientError:
                 let ids = batch.map { $0.messageId }.joined(separator: ",")
-                Logger.warn("Overflow drain dropping bad batch (\(resp.statusCode)); messageIds=\(ids)")
-                await queue.removeOverflowBatch(count: batch.count)
+                Logger.warn("Disk drain dropping bad batch (\(resp.statusCode)); messageIds=\(ids)")
+                remaining.removeFirst(take)
             }
+        }
+
+        // Persist final state. If remaining is empty, this deletes any stale checkpoint
+        // from an earlier iteration. If non-empty, it's the offline-mid-drain remainder.
+        await queue.writeDiskStore(remaining)
+        if remaining.isEmpty {
+            Logger.log("Disk store drain complete")
+        } else {
+            Logger.log("Disk drain paused (offline mid-drain) — persisted \(remaining.count) event(s)")
         }
     }
 
     private func processUntilEmpty() async {
         while await queue.count > 0 {
             guard !isOffline else {
-                Logger.log("Offline — flushing \(await queue.count) event(s) to overflow disk")
-                await queue.flushToOverflowDisk()
+                Logger.log("Offline — flushing \(await queue.count) event(s) to disk")
+                await queue.flushMemoryToDisk()
                 return
             }
 

--- a/Sources/MetaRouter/network/Dispatcher.swift
+++ b/Sources/MetaRouter/network/Dispatcher.swift
@@ -42,6 +42,7 @@ public actor Dispatcher {
     private var tracingEnabled = false
     private var consecutiveRetries: Int = 0
     private var isOffline = false
+    private var isDraining = false
 
     /// Primary init accepting a PersistentEventQueue (used by AnalyticsClient).
     public init(
@@ -93,20 +94,30 @@ public actor Dispatcher {
     }
 
     /// Update offline state. Idempotent — only acts on actual transitions.
+    /// When going offline, enables overflow buffering on the queue.
+    /// When coming online, disables overflow, resets circuit breaker, flushes memory queue,
+    /// and starts draining overflow from disk to network in the background.
     public func setOffline(_ offline: Bool) async {
         if !isOffline && offline {
             // Going offline: stop retrying (no point while offline)
             isOffline = true
             retryTimerTask?.cancel()
             retryTimerTask = nil
+            await queue.setOfflineOverflowEnabled(true)
             Logger.log("Dispatcher paused — device is offline")
         } else if isOffline && !offline {
             // Coming back online: reset stale backoff and flush immediately
             isOffline = false
+            await queue.setOfflineOverflowEnabled(false)
             breaker.reset()
             consecutiveRetries = 0
             Logger.log("Dispatcher resumed — device is online, triggering flush")
-            await flush()
+            // Two independent flush paths:
+            await flush() // (1) memory queue → network
+            // (2) disk overflow → network directly (background)
+            Task { [weak self] in
+                await self?.drainOverflowToNetwork()
+            }
         }
     }
 
@@ -212,6 +223,68 @@ public actor Dispatcher {
         return isFlushing
     }
 
+    /// Send a batch of events directly to the network, bypassing the memory queue.
+    /// Used by overflow drain to flush disk events without loading into memory.
+    /// Returns true on 2xx success, false on any failure.
+    public func sendBatchDirect(_ events: [EnrichedEventPayload]) async -> Bool {
+        guard !events.isEmpty else { return true }
+
+        var batch = events
+        let sentAt = Self.isoFormatter.string(from: Date())
+        for i in 0..<batch.count {
+            batch[i].sentAt = sentAt
+        }
+
+        let payload = ["batch": batch]
+        let body: Data
+        do {
+            body = try Self.jsonEncoder.encode(payload)
+        } catch {
+            Logger.error("Failed to encode overflow batch: \(error)")
+            return false
+        }
+
+        let url = options.ingestionHost.appendingPathComponent(config.endpointPath)
+
+        do {
+            let resp = try await http.postJSON(url: url, body: body, timeoutMs: config.timeoutMs, additionalHeaders: nil)
+            if (200..<300).contains(resp.statusCode) {
+                breaker.onSuccess()
+                return true
+            } else {
+                Logger.warn("Overflow batch send failed with status \(resp.statusCode)")
+                return false
+            }
+        } catch {
+            Logger.warn("Overflow batch send failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Drain overflow events from disk directly to network in batches.
+    /// Called on offline→online transition as an independent flush pipeline.
+    /// Does NOT load events into the memory queue.
+    public func drainOverflowToNetwork() async {
+        guard !isDraining else { return }
+        isDraining = true
+        defer { isDraining = false }
+
+        await queue.flushOverflowBufferToDisk()
+
+        while !isOffline {
+            let batch = await queue.readOverflowBatch(max: 100)
+            guard !batch.isEmpty else { break }
+
+            let success = await sendBatchDirect(batch)
+            if success {
+                await queue.removeOverflowBatch(count: batch.count)
+                Logger.log("Drained \(batch.count) overflow events from disk to network")
+            } else {
+                Logger.warn("Overflow drain stopped — will retry on next online transition")
+                break
+            }
+        }
+    }
 
     private func processUntilEmpty() async {
         while await queue.count > 0 {

--- a/Sources/MetaRouter/network/Dispatcher.swift
+++ b/Sources/MetaRouter/network/Dispatcher.swift
@@ -1,8 +1,31 @@
 import Foundation
 
+/// Shared classification of HTTP status codes used by both the dispatcher and the overflow drain.
+public enum ResponseCategory: Sendable {
+    case success
+    case serverError
+    case rateLimited
+    case payloadTooLarge
+    case fatalConfig
+    case clientError
+
+    public static func from(_ statusCode: Int) -> ResponseCategory {
+        switch statusCode {
+        case 200..<300: return .success
+        case 500..<600, 408: return .serverError
+        case 429: return .rateLimited
+        case 413: return .payloadTooLarge
+        case 401, 403, 404: return .fatalConfig
+        case 400..<500: return .clientError
+        default: return .clientError
+        }
+    }
+}
+
 /// Event dispatcher that batches, posts, and applies retry logic per networkBehavior spec
 public actor Dispatcher {
     public typealias FatalConfigHandler = @Sendable (_ status: Int) -> Void
+    public typealias FlushCompleteHandler = @Sendable () async -> Void
     public struct Config: Sendable {
         public let endpointPath: String
         public let timeoutMs: Int
@@ -34,6 +57,7 @@ public actor Dispatcher {
     private let breaker: CircuitBreaker
     private var maxBatchSize: Int
     private var onFatalConfigError: FatalConfigHandler?
+    private var onFlushComplete: FlushCompleteHandler?
 
     private var flushTimerTask: Task<Void, Never>? = nil
     private var retryTimerTask: Task<Void, Never>? = nil
@@ -88,14 +112,18 @@ public actor Dispatcher {
         self.onFatalConfigError = handler
     }
 
+    public func setFlushCompleteHandler(_ handler: FlushCompleteHandler?) {
+        self.onFlushComplete = handler
+    }
+
     public func setTracing(_ enabled: Bool) {
         self.tracingEnabled = enabled
         Logger.log("Tracing \(enabled ? "enabled" : "disabled")")
     }
 
     /// Update offline state. Idempotent — only acts on actual transitions.
-    /// When going offline, enables overflow buffering on the queue.
-    /// When coming online, disables overflow, resets circuit breaker, flushes memory queue,
+    /// When going offline, stops retrying (no point while offline).
+    /// When coming online, resets circuit breaker, flushes memory queue,
     /// and starts draining overflow from disk to network in the background.
     public func setOffline(_ offline: Bool) async {
         if !isOffline && offline {
@@ -103,12 +131,10 @@ public actor Dispatcher {
             isOffline = true
             retryTimerTask?.cancel()
             retryTimerTask = nil
-            await queue.setOfflineOverflowEnabled(true)
             Logger.log("Dispatcher paused — device is offline")
         } else if isOffline && !offline {
             // Coming back online: reset stale backoff and flush immediately
             isOffline = false
-            await queue.setOfflineOverflowEnabled(false)
             breaker.reset()
             consecutiveRetries = 0
             Logger.log("Dispatcher resumed — device is online, triggering flush")
@@ -174,6 +200,10 @@ public actor Dispatcher {
                 "Flush completed successfully",
                 writeKey: options.writeKey,
                 host: options.ingestionHost.absoluteString)
+            // Fire onFlushComplete only when online — triggers overflow drain
+            if !isOffline, let handler = onFlushComplete {
+                await handler()
+            }
         }
     }
 
@@ -225,9 +255,9 @@ public actor Dispatcher {
 
     /// Send a batch of events directly to the network, bypassing the memory queue.
     /// Used by overflow drain to flush disk events without loading into memory.
-    /// Returns true on 2xx success, false on any failure.
-    public func sendBatchDirect(_ events: [EnrichedEventPayload]) async -> Bool {
-        guard !events.isEmpty else { return true }
+    /// Returns the NetworkResponse on success/HTTP error, nil on network/encoding failure.
+    public func sendBatchDirect(_ events: [EnrichedEventPayload]) async -> NetworkResponse? {
+        guard !events.isEmpty else { return NetworkResponse(statusCode: 200, headers: [:], body: Data()) }
 
         var batch = events
         let sentAt = Self.isoFormatter.string(from: Date())
@@ -241,7 +271,7 @@ public actor Dispatcher {
             body = try Self.jsonEncoder.encode(payload)
         } catch {
             Logger.error("Failed to encode overflow batch: \(error)")
-            return false
+            return nil
         }
 
         let url = options.ingestionHost.appendingPathComponent(config.endpointPath)
@@ -250,38 +280,78 @@ public actor Dispatcher {
             let resp = try await http.postJSON(url: url, body: body, timeoutMs: config.timeoutMs, additionalHeaders: nil)
             if (200..<300).contains(resp.statusCode) {
                 breaker.onSuccess()
-                return true
             } else {
                 Logger.warn("Overflow batch send failed with status \(resp.statusCode)")
-                return false
             }
+            return resp
         } catch {
             Logger.warn("Overflow batch send failed: \(error.localizedDescription)")
-            return false
+            return nil
         }
     }
 
     /// Drain overflow events from disk directly to network in batches.
-    /// Called on offline→online transition as an independent flush pipeline.
+    /// Called on offline→online transition, after successful flush, or at startup.
     /// Does NOT load events into the memory queue.
+    ///
+    /// Response handling per category:
+    /// - SUCCESS: remove batch, restore batch size, continue
+    /// - PAYLOAD_TOO_LARGE (413): halve batch size, retry. Drop at batchSize=1
+    /// - SERVER_ERROR / RATE_LIMITED (5xx/408/429): stop, retry on next online transition
+    /// - FATAL_CONFIG (401/403/404): delete overflow store entirely
+    /// - CLIENT_ERROR (other 4xx): drop batch, continue
+    /// - Network failure (nil): stop, retry on next online transition
     public func drainOverflowToNetwork() async {
         guard !isDraining else { return }
         isDraining = true
         defer { isDraining = false }
 
-        await queue.flushOverflowBufferToDisk()
+        var drainBatchSize = config.initialMaxBatchSize
 
-        while !isOffline {
-            let batch = await queue.readOverflowBatch(max: 100)
-            guard !batch.isEmpty else { break }
+        drainLoop: while !isOffline {
+            let batch = await queue.readOverflowBatch(max: drainBatchSize)
+            guard !batch.isEmpty else { break drainLoop }
 
-            let success = await sendBatchDirect(batch)
-            if success {
+            guard let resp = await sendBatchDirect(batch) else {
+                Logger.warn("Overflow drain stopped (network failure) — will retry on next online transition")
+                break drainLoop
+            }
+
+            let category = ResponseCategory.from(resp.statusCode)
+            switch category {
+            case .success:
                 await queue.removeOverflowBatch(count: batch.count)
                 Logger.log("Drained \(batch.count) overflow events from disk to network")
-            } else {
-                Logger.warn("Overflow drain stopped — will retry on next online transition")
-                break
+                // Gradually recover batch size after 413-induced reduction
+                if drainBatchSize < config.initialMaxBatchSize {
+                    drainBatchSize = min(drainBatchSize * 2, config.initialMaxBatchSize)
+                }
+
+            case .payloadTooLarge:
+                if drainBatchSize > 1 {
+                    drainBatchSize = max(1, drainBatchSize / 2)
+                    Logger.warn("Overflow drain 413 — halving batch size to \(drainBatchSize)")
+                } else {
+                    // Drop at batchSize=1 — single event is too large
+                    let ids = batch.map { $0.messageId }.joined(separator: ",")
+                    Logger.warn("Overflow drain dropping oversize event(s) at batchSize=1; messageIds=\(ids)")
+                    await queue.removeOverflowBatch(count: batch.count)
+                }
+
+            case .serverError, .rateLimited:
+                Logger.warn("Overflow drain stopped (\(resp.statusCode)) — will retry on next online transition")
+                break drainLoop
+
+            case .fatalConfig:
+                Logger.error("Overflow drain fatal config error (\(resp.statusCode)) — deleting overflow store")
+                await queue.deleteOverflowDisk()
+                onFatalConfigError?(resp.statusCode)
+                return
+
+            case .clientError:
+                let ids = batch.map { $0.messageId }.joined(separator: ",")
+                Logger.warn("Overflow drain dropping bad batch (\(resp.statusCode)); messageIds=\(ids)")
+                await queue.removeOverflowBatch(count: batch.count)
             }
         }
     }
@@ -289,7 +359,8 @@ public actor Dispatcher {
     private func processUntilEmpty() async {
         while await queue.count > 0 {
             guard !isOffline else {
-                Logger.log("Offline — pausing HTTP attempts, \(await queue.count) event(s) queued")
+                Logger.log("Offline — flushing \(await queue.count) event(s) to overflow disk")
+                await queue.flushToOverflowDisk()
                 return
             }
 

--- a/Sources/MetaRouter/network/Dispatcher.swift
+++ b/Sources/MetaRouter/network/Dispatcher.swift
@@ -48,7 +48,6 @@ public actor Dispatcher {
         }
     }
 
-    nonisolated(unsafe) private static let isoFormatter = ISO8601DateFormatter()
     private static let jsonEncoder = JSONEncoder()
 
     private let options: InitOptions
@@ -81,28 +80,6 @@ public actor Dispatcher {
         self.http = http
         self.breaker = breaker
         self.queue = persistentQueue
-        self.maxBatchSize = config.initialMaxBatchSize
-        self.config = config
-        self.onFatalConfigError = onFatalConfigError
-    }
-
-    /// Backward-compatible init (tests, simple usage). Creates an internal PersistentEventQueue.
-    public init(
-        options: InitOptions,
-        http: Networking = NetworkClient(),
-        breaker: CircuitBreaker = CircuitBreaker(),
-        queueCapacity: Int = 2000,
-        config: Config = Config(),
-        onFatalConfigError: FatalConfigHandler? = nil
-    ) {
-        self.options = options
-        self.http = http
-        self.breaker = breaker
-        self.queue = PersistentEventQueue(
-            diskStore: DiskStorage(baseDirectory: FileManager.default.temporaryDirectory
-                .appendingPathComponent("metarouter-noop-\(UUID().uuidString)")),
-            maxEventCount: queueCapacity
-        )
         self.maxBatchSize = config.initialMaxBatchSize
         self.config = config
         self.onFatalConfigError = onFatalConfigError
@@ -259,7 +236,7 @@ public actor Dispatcher {
         guard !events.isEmpty else { return NetworkResponse(statusCode: 200, headers: [:], body: Data()) }
 
         var batch = events
-        let sentAt = Self.isoFormatter.string(from: Date())
+        let sentAt = DateFormatters.iso8601.string(from: Date())
         for i in 0..<batch.count {
             batch[i].sentAt = sentAt
         }
@@ -409,7 +386,7 @@ public actor Dispatcher {
             guard !batch.isEmpty else { return }
             
             // Add sentAt timestamp to all events in batch
-            let sentAt = Self.isoFormatter.string(from: Date())
+            let sentAt = DateFormatters.iso8601.string(from: Date())
             for i in 0..<batch.count {
                 batch[i].sentAt = sentAt
             }

--- a/Sources/MetaRouter/network/NetworkMonitor.swift
+++ b/Sources/MetaRouter/network/NetworkMonitor.swift
@@ -15,6 +15,15 @@ public protocol NetworkReachability: AnyObject, Sendable {
     func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void)
     /// Tear down monitoring.
     func stop()
+    /// Force-check the underlying path and fire callback if status drifted.
+    /// Fallback for cases where the event-driven handler misses a transition
+    /// (known simulator quirk with NWPathMonitor on WiFi reconnect).
+    func reconcile()
+}
+
+extension NetworkReachability {
+    /// Default no-op for stubs/tests.
+    public func reconcile() {}
 }
 
 /// Persistent NWPathMonitor wrapper that publishes connectivity state.
@@ -67,5 +76,24 @@ public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
         self.monitor = nil
         lock.unlock()
         mon?.cancel()
+    }
+
+    /// Force-check NWPathMonitor.currentPath and fire callback if status drifted.
+    /// Catches transitions that pathUpdateHandler missed (known simulator quirk).
+    public func reconcile() {
+        guard let monitor = self.monitor else { return }
+        let path = monitor.currentPath
+        let newStatus: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
+
+        lock.lock()
+        let oldStatus = _currentStatus
+        _currentStatus = newStatus
+        let callback = handler
+        lock.unlock()
+
+        if oldStatus != newStatus {
+            Logger.log("Network status reconciled: \(oldStatus.rawValue) -> \(newStatus.rawValue) (pathUpdateHandler missed this transition)")
+            callback?(newStatus)
+        }
     }
 }

--- a/Sources/MetaRouter/network/NetworkMonitor.swift
+++ b/Sources/MetaRouter/network/NetworkMonitor.swift
@@ -39,6 +39,7 @@ public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
         pathMonitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
             let newStatus: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
+            Logger.log("NWPathMonitor update: status=\(path.status), interfaces=\(path.availableInterfaces.map(\.type)), expensive=\(path.isExpensive), constrained=\(path.isConstrained) → \(newStatus.rawValue)")
             self.lock.lock()
             let oldStatus = self._currentStatus
             self._currentStatus = newStatus

--- a/Sources/MetaRouter/network/NetworkMonitor.swift
+++ b/Sources/MetaRouter/network/NetworkMonitor.swift
@@ -15,15 +15,6 @@ public protocol NetworkReachability: AnyObject, Sendable {
     func onStatusChange(_ handler: @escaping @Sendable (NetworkStatus) -> Void)
     /// Tear down monitoring.
     func stop()
-    /// Force-check the underlying path and fire callback if status drifted.
-    /// Fallback for cases where the event-driven handler misses a transition
-    /// (known simulator quirk with NWPathMonitor on WiFi reconnect).
-    func reconcile()
-}
-
-extension NetworkReachability {
-    /// Default no-op for stubs/tests.
-    public func reconcile() {}
 }
 
 /// Persistent NWPathMonitor wrapper that publishes connectivity state.
@@ -48,7 +39,6 @@ public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
         pathMonitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
             let newStatus: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
-            Logger.log("NWPathMonitor update: status=\(path.status), interfaces=\(path.availableInterfaces.map(\.type)), expensive=\(path.isExpensive), constrained=\(path.isConstrained) → \(newStatus.rawValue)")
             self.lock.lock()
             let oldStatus = self._currentStatus
             self._currentStatus = newStatus
@@ -56,7 +46,7 @@ public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
             self.lock.unlock()
 
             if oldStatus != newStatus {
-                Logger.log("Network status changed: \(oldStatus.rawValue) -> \(newStatus.rawValue)")
+                Logger.log("Network status changed: \(oldStatus.rawValue) -> \(newStatus.rawValue) (interfaces=\(path.availableInterfaces.map(\.type)), expensive=\(path.isExpensive), constrained=\(path.isConstrained))")
                 callback?(newStatus)
             }
         }
@@ -78,22 +68,4 @@ public final class NetworkMonitor: NetworkReachability, @unchecked Sendable {
         mon?.cancel()
     }
 
-    /// Force-check NWPathMonitor.currentPath and fire callback if status drifted.
-    /// Catches transitions that pathUpdateHandler missed (known simulator quirk).
-    public func reconcile() {
-        guard let monitor = self.monitor else { return }
-        let path = monitor.currentPath
-        let newStatus: NetworkStatus = path.status == .satisfied ? .connected : .disconnected
-
-        lock.lock()
-        let oldStatus = _currentStatus
-        _currentStatus = newStatus
-        let callback = handler
-        lock.unlock()
-
-        if oldStatus != newStatus {
-            Logger.log("Network status reconciled: \(oldStatus.rawValue) -> \(newStatus.rawValue) (pathUpdateHandler missed this transition)")
-            callback?(newStatus)
-        }
-    }
 }

--- a/Sources/MetaRouter/queue/DiskStorage.swift
+++ b/Sources/MetaRouter/queue/DiskStorage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Handles reading, writing, and deleting the queue snapshot file on disk.
+/// Handles reading, writing, and deleting the single event disk store.
 /// All operations are actor-isolated for thread safety.
 ///
 /// Storage location:
@@ -11,7 +11,7 @@ import Foundation
 /// Writes use atomic file replacement to avoid partial-write corruption.
 public actor DiskStorage {
     private static let directoryName = "metarouter/disk-queue"
-    private static let defaultFileName = "queue.v1.json"
+    private static let fileName = "queue.v1.json"
 
     private static let jsonEncoder = JSONEncoder()
     private static let jsonDecoder = JSONDecoder()
@@ -19,21 +19,27 @@ public actor DiskStorage {
     nonisolated public let baseDirectory: URL
     private let filePath: URL
 
-    /// Initialize with an explicit base directory and optional custom filename (for testing).
-    public init(baseDirectory: URL, fileName: String = "queue.v1.json") {
+    /// Initialize with an explicit base directory (for testing).
+    public init(baseDirectory: URL) {
         self.baseDirectory = baseDirectory
-        self.filePath = baseDirectory.appendingPathComponent(fileName)
+        self.filePath = baseDirectory.appendingPathComponent(Self.fileName)
     }
 
     /// Initialize with the platform-default Application Support directory.
-    public init(fileName: String = "queue.v1.json") {
+    public init() {
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         ).first!
         let dir = appSupport.appendingPathComponent(Self.directoryName)
         self.baseDirectory = dir
-        self.filePath = dir.appendingPathComponent(fileName)
+        self.filePath = dir.appendingPathComponent(Self.fileName)
+    }
+
+    /// Cheap file-existence check. Does not parse the file contents.
+    /// Used on boot to initialize the `hasDiskData` flag without a full read.
+    public func exists() -> Bool {
+        FileManager.default.fileExists(atPath: filePath.path)
     }
 
     /// Write a snapshot to disk, fully overwriting any existing file.
@@ -46,21 +52,37 @@ public actor DiskStorage {
             return
         }
 
-        let fm = FileManager.default
-
-        if !fm.fileExists(atPath: baseDirectory.path) {
-            try fm.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
-        }
-
-        var dir = baseDirectory
-        var resourceValues = URLResourceValues()
-        resourceValues.isExcludedFromBackup = true
-        try dir.setResourceValues(resourceValues)
-
+        try ensureDirectory()
         let data = try Self.jsonEncoder.encode(snapshot)
         try data.write(to: filePath, options: .atomic)
-
         Logger.log("Queue snapshot written to disk: \(snapshot.events.count) events, \(data.count) bytes")
+    }
+
+    /// Append events to the existing on-disk store, merging with prior contents.
+    /// Enforces `maxEvents` cap by dropping the oldest events first. Atomic write.
+    /// Used by: capacity overflow, background flush, offline push-back, threshold flush, requeue-at-cap.
+    /// Returns the final on-disk event count.
+    @discardableResult
+    public func append(_ events: [EnrichedEventPayload], maxEvents: Int) throws -> Int {
+        guard !events.isEmpty else {
+            let existing = read()?.events.count ?? 0
+            return existing
+        }
+
+        let existing = read()?.events ?? []
+        var combined = existing + events
+        if maxEvents > 0 && combined.count > maxEvents {
+            let dropCount = combined.count - maxEvents
+            combined = Array(combined.dropFirst(dropCount))
+            Logger.warn("Disk store cap reached — dropped \(dropCount) oldest events")
+        }
+
+        try ensureDirectory()
+        let snapshot = QueueSnapshot(events: combined)
+        let data = try Self.jsonEncoder.encode(snapshot)
+        try data.write(to: filePath, options: .atomic)
+        Logger.log("Disk store append: +\(events.count) events, \(combined.count) total on disk")
+        return combined.count
     }
 
     /// Read the snapshot from disk. Returns nil if no file exists.
@@ -87,5 +109,16 @@ public actor DiskStorage {
     public func delete() {
         try? FileManager.default.removeItem(at: filePath)
         Logger.log("Queue snapshot deleted from disk")
+    }
+
+    private func ensureDirectory() throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: baseDirectory.path) {
+            try fm.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+        }
+        var dir = baseDirectory
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try dir.setResourceValues(resourceValues)
     }
 }

--- a/Sources/MetaRouter/queue/DiskStorage.swift
+++ b/Sources/MetaRouter/queue/DiskStorage.swift
@@ -11,29 +11,29 @@ import Foundation
 /// Writes use atomic file replacement to avoid partial-write corruption.
 public actor DiskStorage {
     private static let directoryName = "metarouter/disk-queue"
-    private static let fileName = "queue.v1.json"
+    private static let defaultFileName = "queue.v1.json"
 
     private static let jsonEncoder = JSONEncoder()
     private static let jsonDecoder = JSONDecoder()
 
-    private let baseDirectory: URL
+    nonisolated public let baseDirectory: URL
     private let filePath: URL
 
-    /// Initialize with an explicit base directory (for testing).
-    public init(baseDirectory: URL) {
+    /// Initialize with an explicit base directory and optional custom filename (for testing).
+    public init(baseDirectory: URL, fileName: String = "queue.v1.json") {
         self.baseDirectory = baseDirectory
-        self.filePath = baseDirectory.appendingPathComponent(Self.fileName)
+        self.filePath = baseDirectory.appendingPathComponent(fileName)
     }
 
     /// Initialize with the platform-default Application Support directory.
-    public init() {
+    public init(fileName: String = "queue.v1.json") {
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
         ).first!
         let dir = appSupport.appendingPathComponent(Self.directoryName)
         self.baseDirectory = dir
-        self.filePath = dir.appendingPathComponent(Self.fileName)
+        self.filePath = dir.appendingPathComponent(fileName)
     }
 
     /// Write a snapshot to disk, fully overwriting any existing file.

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -30,9 +30,6 @@ public actor PersistentEventQueue {
     // Offline overflow support
     private let overflowDiskStorage: DiskStorage?
     private let maxOfflineDiskEvents: Int
-    private var offlineOverflowEnabled = false
-    private var overflowBuffer: [EnrichedEventPayload] = []
-    private static let overflowBatchThreshold = 100
 
     public init(
         diskStorage: DiskStorage,
@@ -53,28 +50,25 @@ public actor PersistentEventQueue {
         self.maxOfflineDiskEvents = max(0, maxOfflineDiskEvents)
     }
 
-    /// Enqueue an event to the in-memory buffer. No disk I/O.
-    /// When offline overflow is enabled and the queue is at capacity, the oldest event
-    /// is redirected to the overflow buffer (for batched disk write) instead of being dropped.
+    /// Enqueue an event to the in-memory buffer.
+    /// When the queue is at capacity and overflow disk storage exists, the entire memory queue
+    /// is flushed to overflow disk before inserting the new event. This happens regardless of
+    /// online/offline state — capacity overflow always goes to disk, never drops.
     /// Returns the queue count after insertion (atomic with the enqueue).
     @discardableResult
     public func enqueue(_ event: EnrichedEventPayload) async -> Int {
-        // When offline overflow is enabled, intercept the overflow before EventQueue drops it
-        if offlineOverflowEnabled, overflowDiskStorage != nil {
+        // When at capacity and overflow disk exists, flush entire queue to disk
+        if overflowDiskStorage != nil {
             let currentCount = await memoryQueue.count
             if currentCount >= maxEventCount {
-                let evicted = await memoryQueue.drain(max: 1)
-                for e in evicted {
-                    estimatedBytes -= Self.estimateEventSize(e)
-                    await bufferOverflowEvent(e)
-                }
+                await flushToOverflowDisk()
             }
         }
 
         let prevCount = await memoryQueue.count
         let newCount = await memoryQueue.enqueue(event)
         let eventSize = Self.estimateEventSize(event)
-        // If an overflow drop happened (no overflow enabled), approximate the dropped event as average size
+        // If a drop happened (no overflow storage configured), approximate the dropped event as average size
         if newCount <= prevCount, estimatedBytes > 0, prevCount > 0 {
             estimatedBytes -= estimatedBytes / prevCount
         }
@@ -114,7 +108,6 @@ public actor PersistentEventQueue {
         await memoryQueue.clear()
         estimatedBytes = 0
         await diskStorage.delete()
-        overflowBuffer.removeAll()
         if let overflowDisk = overflowDiskStorage {
             await overflowDisk.delete()
         }
@@ -141,13 +134,10 @@ public actor PersistentEventQueue {
 
     /// Flush current memory state to disk. Full overwrite.
     /// Called on: app background, app terminate (best-effort), explicit flush, threshold.
-    /// Also flushes the overflow buffer to its separate disk file.
     public func flushToDisk() async throws {
         let events = await peekAll()
         let snapshot = QueueSnapshot(events: events)
         try await diskStorage.write(snapshot)
-        // Also persist any buffered overflow events
-        await flushOverflowBufferToDisk()
     }
 
     /// Rehydrate events from disk into memory.
@@ -195,32 +185,18 @@ public actor PersistentEventQueue {
 
     // MARK: - Offline Overflow
 
-    /// Enable or disable offline overflow mode.
-    /// When enabled, events evicted from the memory queue are buffered for disk write
-    /// instead of being dropped. No-op if no overflow disk storage was configured.
-    public func setOfflineOverflowEnabled(_ enabled: Bool) {
-        guard overflowDiskStorage != nil else { return }
-        offlineOverflowEnabled = enabled
-    }
-
-    /// Buffer an evicted event for batched disk write.
-    private func bufferOverflowEvent(_ event: EnrichedEventPayload) async {
-        overflowBuffer.append(event)
-        if overflowBuffer.count >= Self.overflowBatchThreshold {
-            await flushOverflowBufferToDisk()
-        }
-    }
-
-    /// Flush the in-memory overflow buffer to the overflow disk store.
+    /// Flush the entire memory queue to the overflow disk store and reset memory to 0.
     /// Merges with existing disk contents and enforces maxOfflineDiskEvents cap.
-    /// Called when buffer reaches batch threshold, on app backgrounding, or before drain.
-    public func flushOverflowBufferToDisk() async {
-        guard let overflowDisk = overflowDiskStorage, !overflowBuffer.isEmpty else { return }
-        let batch = overflowBuffer
-        overflowBuffer.removeAll()
+    /// Called when memory queue hits capacity (automatic) or by the dispatcher when offline.
+    @discardableResult
+    public func flushToOverflowDisk() async -> Bool {
+        guard let overflowDisk = overflowDiskStorage else { return false }
+        let events = await memoryQueue.drain(max: Int.max)
+        guard !events.isEmpty else { return false }
+        estimatedBytes = 0
 
         let existing = await overflowDisk.read()
-        var combined = (existing?.events ?? []) + batch
+        var combined = (existing?.events ?? []) + events
         if combined.count > maxOfflineDiskEvents {
             let dropCount = combined.count - maxOfflineDiskEvents
             combined = Array(combined.dropFirst(dropCount))
@@ -228,19 +204,23 @@ public actor PersistentEventQueue {
         }
         do {
             try await overflowDisk.write(QueueSnapshot(events: combined))
-            Logger.log("Overflow buffer flushed to disk: \(batch.count) events, \(combined.count) total on disk")
+            Logger.log("Memory queue flushed to overflow disk: \(events.count) events, \(combined.count) total on disk")
+            return true
         } catch {
-            Logger.warn("Failed to flush overflow buffer to disk: \(error)")
-            // Re-buffer events that failed to persist
-            overflowBuffer.insert(contentsOf: batch, at: 0)
+            Logger.warn("Failed to flush memory queue to overflow disk: \(error)")
+            // Re-enqueue events that failed to persist
+            await memoryQueue.requeueToFront(events)
+            for event in events {
+                estimatedBytes += Self.estimateEventSize(event)
+            }
+            return false
         }
     }
 
-    /// Read a batch of overflow events from disk. Flushes buffer first.
+    /// Read a batch of overflow events from disk.
     /// Returns empty array if no overflow disk storage is configured or no events exist.
     public func readOverflowBatch(max count: Int) async -> [EnrichedEventPayload] {
         guard let overflowDisk = overflowDiskStorage else { return [] }
-        await flushOverflowBufferToDisk()
         guard let snapshot = await overflowDisk.read() else { return [] }
         let events = snapshot.events
         guard !events.isEmpty else { return [] }
@@ -264,12 +244,10 @@ public actor PersistentEventQueue {
         }
     }
 
-    /// Number of events currently in the overflow buffer + disk.
-    public func overflowCount() async -> Int {
-        let bufferCount = overflowBuffer.count
-        guard let overflowDisk = overflowDiskStorage else { return bufferCount }
-        let diskCount = await overflowDisk.read()?.events.count ?? 0
-        return bufferCount + diskCount
+    /// Delete the overflow disk store entirely.
+    public func deleteOverflowDisk() async {
+        guard let overflowDisk = overflowDiskStorage else { return }
+        await overflowDisk.delete()
     }
 
     // MARK: - Private Helpers

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -134,8 +134,11 @@ public actor PersistentEventQueue {
 
     /// Flush current memory state to disk. Full overwrite.
     /// Called on: app background, app terminate (best-effort), explicit flush, threshold.
+    /// No-op if the memory queue is empty (avoids misleading "deleted" log when events
+    /// have already been flushed to overflow disk).
     public func flushToDisk() async throws {
         let events = await peekAll()
+        guard !events.isEmpty else { return }
         let snapshot = QueueSnapshot(events: events)
         try await diskStorage.write(snapshot)
     }

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -27,12 +27,21 @@ public actor PersistentEventQueue {
     /// on enqueue/drain/requeue/clear to avoid re-encoding the entire queue on every offer().
     private var estimatedBytes: Int = 0
 
+    // Offline overflow support
+    private let overflowDiskStorage: DiskStorage?
+    private let maxOfflineDiskEvents: Int
+    private var offlineOverflowEnabled = false
+    private var overflowBuffer: [EnrichedEventPayload] = []
+    private static let overflowBatchThreshold = 100
+
     public init(
         diskStorage: DiskStorage,
         maxEventCount: Int = 2000,
         maxSizeBytes: Int = 5_242_880, // 5MB
         flushThresholdCount: Int = 500,
-        flushThresholdBytes: Int = 2_097_152 // 2MB
+        flushThresholdBytes: Int = 2_097_152, // 2MB
+        overflowDiskStorage: DiskStorage? = nil,
+        maxOfflineDiskEvents: Int = 10000
     ) {
         self.diskStorage = diskStorage
         self.maxEventCount = max(1, maxEventCount)
@@ -40,16 +49,32 @@ public actor PersistentEventQueue {
         self.flushThresholdCount = max(1, flushThresholdCount)
         self.flushThresholdBytes = max(1, flushThresholdBytes)
         self.memoryQueue = EventQueue<EnrichedEventPayload>(capacity: maxEventCount)
+        self.overflowDiskStorage = overflowDiskStorage
+        self.maxOfflineDiskEvents = max(0, maxOfflineDiskEvents)
     }
 
     /// Enqueue an event to the in-memory buffer. No disk I/O.
+    /// When offline overflow is enabled and the queue is at capacity, the oldest event
+    /// is redirected to the overflow buffer (for batched disk write) instead of being dropped.
     /// Returns the queue count after insertion (atomic with the enqueue).
     @discardableResult
     public func enqueue(_ event: EnrichedEventPayload) async -> Int {
+        // When offline overflow is enabled, intercept the overflow before EventQueue drops it
+        if offlineOverflowEnabled, overflowDiskStorage != nil {
+            let currentCount = await memoryQueue.count
+            if currentCount >= maxEventCount {
+                let evicted = await memoryQueue.drain(max: 1)
+                for e in evicted {
+                    estimatedBytes -= Self.estimateEventSize(e)
+                    await bufferOverflowEvent(e)
+                }
+            }
+        }
+
         let prevCount = await memoryQueue.count
         let newCount = await memoryQueue.enqueue(event)
         let eventSize = Self.estimateEventSize(event)
-        // If an overflow drop happened, approximate the dropped event as average size
+        // If an overflow drop happened (no overflow enabled), approximate the dropped event as average size
         if newCount <= prevCount, estimatedBytes > 0, prevCount > 0 {
             estimatedBytes -= estimatedBytes / prevCount
         }
@@ -84,11 +109,15 @@ public actor PersistentEventQueue {
         }
     }
 
-    /// Clear all events from memory AND delete the disk snapshot file.
+    /// Clear all events from memory AND delete both disk snapshot files (queue + overflow).
     public func clear() async {
         await memoryQueue.clear()
         estimatedBytes = 0
         await diskStorage.delete()
+        overflowBuffer.removeAll()
+        if let overflowDisk = overflowDiskStorage {
+            await overflowDisk.delete()
+        }
     }
 
     /// Current number of events in memory.
@@ -112,10 +141,13 @@ public actor PersistentEventQueue {
 
     /// Flush current memory state to disk. Full overwrite.
     /// Called on: app background, app terminate (best-effort), explicit flush, threshold.
+    /// Also flushes the overflow buffer to its separate disk file.
     public func flushToDisk() async throws {
         let events = await peekAll()
         let snapshot = QueueSnapshot(events: events)
         try await diskStorage.write(snapshot)
+        // Also persist any buffered overflow events
+        await flushOverflowBufferToDisk()
     }
 
     /// Rehydrate events from disk into memory.
@@ -160,6 +192,87 @@ public actor PersistentEventQueue {
         return events.count
     }
 
+
+    // MARK: - Offline Overflow
+
+    /// Enable or disable offline overflow mode.
+    /// When enabled, events evicted from the memory queue are buffered for disk write
+    /// instead of being dropped. No-op if no overflow disk storage was configured.
+    public func setOfflineOverflowEnabled(_ enabled: Bool) {
+        guard overflowDiskStorage != nil else { return }
+        offlineOverflowEnabled = enabled
+    }
+
+    /// Buffer an evicted event for batched disk write.
+    private func bufferOverflowEvent(_ event: EnrichedEventPayload) async {
+        overflowBuffer.append(event)
+        if overflowBuffer.count >= Self.overflowBatchThreshold {
+            await flushOverflowBufferToDisk()
+        }
+    }
+
+    /// Flush the in-memory overflow buffer to the overflow disk store.
+    /// Merges with existing disk contents and enforces maxOfflineDiskEvents cap.
+    /// Called when buffer reaches batch threshold, on app backgrounding, or before drain.
+    public func flushOverflowBufferToDisk() async {
+        guard let overflowDisk = overflowDiskStorage, !overflowBuffer.isEmpty else { return }
+        let batch = overflowBuffer
+        overflowBuffer.removeAll()
+
+        let existing = await overflowDisk.read()
+        var combined = (existing?.events ?? []) + batch
+        if combined.count > maxOfflineDiskEvents {
+            let dropCount = combined.count - maxOfflineDiskEvents
+            combined = Array(combined.dropFirst(dropCount))
+            Logger.warn("Offline overflow disk cap reached — dropped \(dropCount) oldest events")
+        }
+        do {
+            try await overflowDisk.write(QueueSnapshot(events: combined))
+            Logger.log("Overflow buffer flushed to disk: \(batch.count) events, \(combined.count) total on disk")
+        } catch {
+            Logger.warn("Failed to flush overflow buffer to disk: \(error)")
+            // Re-buffer events that failed to persist
+            overflowBuffer.insert(contentsOf: batch, at: 0)
+        }
+    }
+
+    /// Read a batch of overflow events from disk. Flushes buffer first.
+    /// Returns empty array if no overflow disk storage is configured or no events exist.
+    public func readOverflowBatch(max count: Int) async -> [EnrichedEventPayload] {
+        guard let overflowDisk = overflowDiskStorage else { return [] }
+        await flushOverflowBufferToDisk()
+        guard let snapshot = await overflowDisk.read() else { return [] }
+        let events = snapshot.events
+        guard !events.isEmpty else { return [] }
+        return Array(events.prefix(min(count, events.count)))
+    }
+
+    /// Remove the first `count` events from the overflow disk store.
+    /// Deletes the file entirely if no events remain.
+    public func removeOverflowBatch(count: Int) async {
+        guard let overflowDisk = overflowDiskStorage else { return }
+        guard let snapshot = await overflowDisk.read() else { return }
+        let remaining = Array(snapshot.events.dropFirst(count))
+        if remaining.isEmpty {
+            await overflowDisk.delete()
+        } else {
+            do {
+                try await overflowDisk.write(QueueSnapshot(events: remaining))
+            } catch {
+                Logger.warn("Failed to update overflow disk after batch removal: \(error)")
+            }
+        }
+    }
+
+    /// Number of events currently in the overflow buffer + disk.
+    public func overflowCount() async -> Int {
+        let bufferCount = overflowBuffer.count
+        guard let overflowDisk = overflowDiskStorage else { return bufferCount }
+        let diskCount = await overflowDisk.read()?.events.count ?? 0
+        return bufferCount + diskCount
+    }
+
+    // MARK: - Private Helpers
 
     /// Peek at all events without removing them. Used for snapshotting.
     private func peekAll() async -> [EnrichedEventPayload] {

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -1,74 +1,95 @@
 import Foundation
 
-/// Persistence-aware event queue. Memory is the primary store; disk is a safety net.
+/// Persistence-aware event queue with a single disk store for both runtime overflow
+/// and crash-safety snapshots. Memory is the fast path; disk is the durability path.
 ///
-/// - `enqueue()` writes to memory only (no disk I/O)
-/// - `drain()` reads from memory only (no disk I/O)
-/// - `flushToDisk()` snapshots current memory state to disk (full overwrite)
-/// - `rehydrate()` loads events from disk (idempotent — disk file deleted after load)
+/// Write paths (all converge to `flushMemoryToDisk`):
+/// - `enqueue()` at capacity — flushes entire memory queue to disk before inserting
+/// - `requeueToFront()` at capacity — flushes memory to disk, then inserts requeued events
+/// - `flushMemoryToDisk()` explicit — called from background lifecycle, threshold, offline push-back
 ///
-/// Capacity: single shared cap — count OR bytes, whichever first. Overflow: drop oldest.
+/// Read path:
+/// - `checkForPersistedEvents()` — cheap boot-time file-existence gate
+/// - `readAllFromDiskAndDelete()` — drain's single-read primitive (atomic actor hop)
+/// - `writeDiskStore(_:)` — drain's checkpoint + "write remainder on failure" primitive
+///
+/// Concurrency:
+/// - `withDiskLock { }` — acquired by the dispatcher for the full `drainDiskStoreToNetwork`
+/// - `flushMemoryToDisk` internally takes the same lock, serializing against drain
 public actor PersistentEventQueue {
 
     private static let jsonEncoder = JSONEncoder()
 
-    /// Events older than this are dropped during rehydration.
+    /// Events older than this are dropped on read-back from disk.
     static let eventTTL: TimeInterval = 7 * 24 * 60 * 60 // 7 days
 
     private let maxEventCount: Int
     private let maxSizeBytes: Int
     private let flushThresholdCount: Int
     private let flushThresholdBytes: Int
-
+    private let maxDiskEvents: Int
 
     private let memoryQueue: EventQueue<EnrichedEventPayload>
-    private let diskStorage: DiskStorage
-    /// Running estimate of serialized bytes in the queue. Updated incrementally
-    /// on enqueue/drain/requeue/clear to avoid re-encoding the entire queue on every offer().
+    private let diskStore: DiskStorage
+    private let diskLock = AsyncMutex()
+
+    /// Running estimate of serialized bytes in the memory queue.
     private var estimatedBytes: Int = 0
 
-    // Offline overflow support
-    private let overflowDiskStorage: DiskStorage?
-    private let maxOfflineDiskEvents: Int
+    /// Lightweight gate for "is there anything on disk worth draining."
+    /// Initialized via `checkForPersistedEvents()` on boot, updated by disk writes/deletes.
+    private var _hasDiskData: Bool = false
+
+    public var hasDiskData: Bool { _hasDiskData }
 
     public init(
-        diskStorage: DiskStorage,
+        diskStore: DiskStorage,
         maxEventCount: Int = 2000,
         maxSizeBytes: Int = 5_242_880, // 5MB
         flushThresholdCount: Int = 500,
         flushThresholdBytes: Int = 2_097_152, // 2MB
-        overflowDiskStorage: DiskStorage? = nil,
-        maxOfflineDiskEvents: Int = 10000
+        maxDiskEvents: Int = 10000
     ) {
-        self.diskStorage = diskStorage
+        self.diskStore = diskStore
         self.maxEventCount = max(1, maxEventCount)
         self.maxSizeBytes = max(1, maxSizeBytes)
         self.flushThresholdCount = max(1, flushThresholdCount)
         self.flushThresholdBytes = max(1, flushThresholdBytes)
         self.memoryQueue = EventQueue<EnrichedEventPayload>(capacity: maxEventCount)
-        self.overflowDiskStorage = overflowDiskStorage
-        self.maxOfflineDiskEvents = max(0, maxOfflineDiskEvents)
+        self.maxDiskEvents = max(0, maxDiskEvents)
     }
 
+    // MARK: - Boot
+
+    /// Cheap file-existence check. Sets `hasDiskData` without parsing the file.
+    /// Returns `true` if there are persisted events on disk.
+    @discardableResult
+    public func checkForPersistedEvents() async -> Bool {
+        let exists = await diskStore.exists()
+        _hasDiskData = exists
+        if exists {
+            Logger.log("Persisted events detected on disk — drain will run when online")
+        } else {
+            Logger.log("No persisted events on disk")
+        }
+        return exists
+    }
+
+    // MARK: - Memory queue operations
+
     /// Enqueue an event to the in-memory buffer.
-    /// When the queue is at capacity and overflow disk storage exists, the entire memory queue
-    /// is flushed to overflow disk before inserting the new event. This happens regardless of
-    /// online/offline state — capacity overflow always goes to disk, never drops.
-    /// Returns the queue count after insertion (atomic with the enqueue).
+    /// When the queue is at capacity, the entire memory queue is flushed to disk first.
+    /// Returns the queue count after insertion.
     @discardableResult
     public func enqueue(_ event: EnrichedEventPayload) async -> Int {
-        // When at capacity and overflow disk exists, flush entire queue to disk
-        if overflowDiskStorage != nil {
-            let currentCount = await memoryQueue.count
-            if currentCount >= maxEventCount {
-                await flushToOverflowDisk()
-            }
+        let currentCount = await memoryQueue.count
+        if currentCount >= maxEventCount {
+            await flushMemoryToDisk()
         }
 
         let prevCount = await memoryQueue.count
         let newCount = await memoryQueue.enqueue(event)
         let eventSize = Self.estimateEventSize(event)
-        // If a drop happened (no overflow storage configured), approximate the dropped event as average size
         if newCount <= prevCount, estimatedBytes > 0, prevCount > 0 {
             estimatedBytes -= estimatedBytes / prevCount
         }
@@ -87,7 +108,14 @@ public actor PersistentEventQueue {
     }
 
     /// Requeue events at the front (used after retryable send failures).
+    /// If memory cannot fit both current contents and the requeued events, flushes
+    /// current memory to disk first so nothing is dropped.
     public func requeueToFront(_ events: [EnrichedEventPayload]) async {
+        guard !events.isEmpty else { return }
+        let currentCount = await memoryQueue.count
+        if currentCount + events.count > maxEventCount {
+            await flushMemoryToDisk()
+        }
         await memoryQueue.requeueToFront(events)
         for event in events {
             estimatedBytes += Self.estimateEventSize(event)
@@ -97,20 +125,16 @@ public actor PersistentEventQueue {
     /// Drop current front batch without requeueing.
     public func dropFront(_ count: Int) async {
         await memoryQueue.dropFront(count)
-        // Conservative: we don't know exact sizes of dropped events, reset estimate
         if await memoryQueue.count == 0 {
             estimatedBytes = 0
         }
     }
 
-    /// Clear all events from memory AND delete both disk snapshot files (queue + overflow).
+    /// Clear all events from memory AND delete the disk store.
     public func clear() async {
         await memoryQueue.clear()
         estimatedBytes = 0
-        await diskStorage.delete()
-        if let overflowDisk = overflowDiskStorage {
-            await overflowDisk.delete()
-        }
+        await deleteDiskStore()
     }
 
     /// Current number of events in memory.
@@ -118,9 +142,7 @@ public actor PersistentEventQueue {
         get async { await memoryQueue.count }
     }
 
-
-    /// Returns true if the in-memory buffer has reached the flush-to-disk threshold.
-    /// Uses a running byte estimate to avoid re-encoding the entire queue on every check.
+    /// Returns true if the memory buffer has reached the flush-to-disk threshold.
     public var needsFlushToDisk: Bool {
         get async {
             let eventCount = await memoryQueue.count
@@ -131,87 +153,99 @@ public actor PersistentEventQueue {
         }
     }
 
+    // MARK: - Disk lock (exposed for Dispatcher's drain)
 
-    /// Flush current memory state to disk. Full overwrite.
-    /// Called on: app background, app terminate (best-effort), explicit flush, threshold.
-    /// No-op if the memory queue is empty (avoids misleading "deleted" log when events
-    /// have already been flushed to overflow disk).
-    public func flushToDisk() async throws {
-        let events = await peekAll()
-        guard !events.isEmpty else { return }
-        let snapshot = QueueSnapshot(events: events)
-        try await diskStorage.write(snapshot)
+    /// Acquire the disk lock. MUST be paired with `releaseDiskLock()`.
+    /// Held by `drainDiskStoreToNetwork` for the entire drain duration so that
+    /// mid-drain memory flushes do not clobber the drain's remainder write.
+    public func acquireDiskLock() async {
+        await diskLock.lock()
     }
 
-    /// Rehydrate events from disk into memory.
-    /// Idempotent — the disk file is deleted after a successful load, so subsequent calls are no-ops.
-    /// Drops events older than `eventTTL` (7 days).
-    /// Returns the number of events loaded.
-    @discardableResult
-    public func rehydrate() async -> Int {
-        guard let snapshot = await diskStorage.read() else {
-            Logger.log("No queue snapshot found on disk — nothing to rehydrate")
-            return 0
-        }
-
-        let now = Date()
-        let iso = ISO8601DateFormatter()
-        var events = snapshot.events.filter { event in
-            guard let ts = iso.date(from: event.timestamp) else { return true }
-            return now.timeIntervalSince(ts) <= Self.eventTTL
-        }
-
-        let expiredCount = snapshot.events.count - events.count
-        if expiredCount > 0 {
-            Logger.warn("Rehydration: dropped \(expiredCount) event(s) older than 7 days")
-        }
-
-        // Enforce capacity: keep newest, drop oldest
-        if events.count > maxEventCount {
-            let dropCount = events.count - maxEventCount
-            events = Array(events.dropFirst(dropCount))
-            Logger.warn("Rehydration: dropped \(dropCount) oldest events to fit capacity \(maxEventCount)")
-        }
-
-        for event in events {
-            await memoryQueue.enqueue(event)
-            estimatedBytes += Self.estimateEventSize(event)
-        }
-
-        // Delete disk file after successful load to prevent stale reads
-        await diskStorage.delete()
-
-        Logger.log("Rehydrated \(events.count) events from disk")
-        return events.count
+    /// Release the disk lock.
+    public func releaseDiskLock() async {
+        await diskLock.unlock()
     }
 
+    // MARK: - Disk operations
 
-    // MARK: - Offline Overflow
-
-    /// Flush the entire memory queue to the overflow disk store and reset memory to 0.
-    /// Merges with existing disk contents and enforces maxOfflineDiskEvents cap.
-    /// Called when memory queue hits capacity (automatic) or by the dispatcher when offline.
+    /// Flush the entire memory queue to disk, merging with existing disk contents
+    /// and enforcing `maxDiskEvents`. Memory is cleared after a successful write.
+    /// Acquires the disk lock — serializes against an in-flight drain.
+    /// Returns `true` if at least one event was persisted.
     @discardableResult
-    public func flushToOverflowDisk() async -> Bool {
-        guard let overflowDisk = overflowDiskStorage else { return false }
+    public func flushMemoryToDisk() async -> Bool {
+        await diskLock.lock()
+        let result = await flushMemoryToDiskInternal()
+        await diskLock.unlock()
+        return result
+    }
+
+    /// Drain's single-read primitive. Reads everything from disk and deletes the file
+    /// in a single actor hop (no suspends between). Caller MUST hold the disk lock.
+    /// Returns the events that were on disk (possibly empty).
+    public func readAllFromDiskAndDelete() async -> [EnrichedEventPayload] {
+        let snapshot = await diskStore.read()
+        let events = snapshot?.events ?? []
+        if !events.isEmpty {
+            await diskStore.delete()
+            _hasDiskData = false
+        } else if _hasDiskData {
+            // File was missing or empty — flag was stale
+            await diskStore.delete()
+            _hasDiskData = false
+        }
+        return events
+    }
+
+    /// Full overwrite of the disk store with the given events.
+    /// Used by drain for checkpoints and "write remainder on failure."
+    /// Caller MUST hold the disk lock.
+    public func writeDiskStore(_ events: [EnrichedEventPayload]) async {
+        guard !events.isEmpty else {
+            await diskStore.delete()
+            _hasDiskData = false
+            return
+        }
+        do {
+            try await diskStore.write(QueueSnapshot(events: events))
+            _hasDiskData = true
+        } catch {
+            Logger.warn("Failed to write disk store: \(error)")
+        }
+    }
+
+    /// Delete the disk store entirely and clear the `hasDiskData` flag.
+    public func deleteDiskStore() async {
+        await diskStore.delete()
+        _hasDiskData = false
+    }
+
+    /// Read a batch from disk without deleting it. Used by tests and callers that
+    /// need to peek at disk contents without the full drain protocol.
+    public func readDiskBatch(max count: Int) async -> [EnrichedEventPayload] {
+        guard let snapshot = await diskStore.read() else { return [] }
+        let events = snapshot.events
+        guard !events.isEmpty else { return [] }
+        return Array(events.prefix(min(count, events.count)))
+    }
+
+    // MARK: - Private helpers
+
+    /// Internal flush — no lock, caller must hold `diskLock` (or be `flushMemoryToDisk`).
+    private func flushMemoryToDiskInternal() async -> Bool {
         let events = await memoryQueue.drain(max: Int.max)
         guard !events.isEmpty else { return false }
         estimatedBytes = 0
 
-        let existing = await overflowDisk.read()
-        var combined = (existing?.events ?? []) + events
-        if combined.count > maxOfflineDiskEvents {
-            let dropCount = combined.count - maxOfflineDiskEvents
-            combined = Array(combined.dropFirst(dropCount))
-            Logger.warn("Offline overflow disk cap reached — dropped \(dropCount) oldest events")
-        }
         do {
-            try await overflowDisk.write(QueueSnapshot(events: combined))
-            Logger.log("Memory queue flushed to overflow disk: \(events.count) events, \(combined.count) total on disk")
+            let total = try await diskStore.append(events, maxEvents: maxDiskEvents)
+            _hasDiskData = total > 0
+            Logger.log("Memory queue flushed to disk: \(events.count) events, \(total) total on disk")
             return true
         } catch {
-            Logger.warn("Failed to flush memory queue to overflow disk: \(error)")
-            // Re-enqueue events that failed to persist
+            Logger.warn("Failed to flush memory queue to disk: \(error)")
+            // Re-enqueue events that failed to persist so they aren't lost
             await memoryQueue.requeueToFront(events)
             for event in events {
                 estimatedBytes += Self.estimateEventSize(event)
@@ -220,52 +254,7 @@ public actor PersistentEventQueue {
         }
     }
 
-    /// Read a batch of overflow events from disk.
-    /// Returns empty array if no overflow disk storage is configured or no events exist.
-    public func readOverflowBatch(max count: Int) async -> [EnrichedEventPayload] {
-        guard let overflowDisk = overflowDiskStorage else { return [] }
-        guard let snapshot = await overflowDisk.read() else { return [] }
-        let events = snapshot.events
-        guard !events.isEmpty else { return [] }
-        return Array(events.prefix(min(count, events.count)))
-    }
-
-    /// Remove the first `count` events from the overflow disk store.
-    /// Deletes the file entirely if no events remain.
-    public func removeOverflowBatch(count: Int) async {
-        guard let overflowDisk = overflowDiskStorage else { return }
-        guard let snapshot = await overflowDisk.read() else { return }
-        let remaining = Array(snapshot.events.dropFirst(count))
-        if remaining.isEmpty {
-            await overflowDisk.delete()
-        } else {
-            do {
-                try await overflowDisk.write(QueueSnapshot(events: remaining))
-            } catch {
-                Logger.warn("Failed to update overflow disk after batch removal: \(error)")
-            }
-        }
-    }
-
-    /// Delete the overflow disk store entirely.
-    public func deleteOverflowDisk() async {
-        guard let overflowDisk = overflowDiskStorage else { return }
-        await overflowDisk.delete()
-    }
-
-    // MARK: - Private Helpers
-
-    /// Peek at all events without removing them. Used for snapshotting.
-    private func peekAll() async -> [EnrichedEventPayload] {
-        let all = await memoryQueue.drain(max: Int.max)
-        if !all.isEmpty {
-            await memoryQueue.requeueToFront(all)
-        }
-        return all
-    }
-
-    /// Fast per-event size estimate. Encodes once per event (at enqueue time only),
-    /// not the entire queue on every threshold check.
+    /// Fast per-event size estimate. Encodes once per event (at enqueue time only).
     private static func estimateEventSize(_ event: EnrichedEventPayload) -> Int {
         (try? jsonEncoder.encode(event))?.count ?? 512
     }

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -59,7 +59,6 @@ public actor PersistentEventQueue {
         self.maxDiskEvents = max(0, maxDiskEvents)
     }
 
-    // MARK: - Boot
 
     /// Cheap file-existence check. Sets `hasDiskData` without parsing the file.
     /// Returns `true` if there are persisted events on disk.
@@ -75,21 +74,19 @@ public actor PersistentEventQueue {
         return exists
     }
 
-    // MARK: - Memory queue operations
-
     /// Enqueue an event to the in-memory buffer.
-    /// When the queue is at capacity, the entire memory queue is flushed to disk first.
-    /// Returns the queue count after insertion.
+    /// When the queue is at capacity (by count OR byte size), the entire memory queue is flushed
+    /// to disk first. Returns the queue count after insertion.
     @discardableResult
     public func enqueue(_ event: EnrichedEventPayload) async -> Int {
         let currentCount = await memoryQueue.count
-        if currentCount >= maxEventCount {
+        let eventSize = Self.estimateEventSize(event)
+        if currentCount >= maxEventCount || estimatedBytes + eventSize > maxSizeBytes {
             await flushMemoryToDisk()
         }
 
         let prevCount = await memoryQueue.count
         let newCount = await memoryQueue.enqueue(event)
-        let eventSize = Self.estimateEventSize(event)
         if newCount <= prevCount, estimatedBytes > 0, prevCount > 0 {
             estimatedBytes -= estimatedBytes / prevCount
         }
@@ -108,18 +105,17 @@ public actor PersistentEventQueue {
     }
 
     /// Requeue events at the front (used after retryable send failures).
-    /// If memory cannot fit both current contents and the requeued events, flushes
-    /// current memory to disk first so nothing is dropped.
+    /// If memory cannot fit both current contents and the requeued events (by count OR bytes),
+    /// flushes current memory to disk first so nothing is dropped.
     public func requeueToFront(_ events: [EnrichedEventPayload]) async {
         guard !events.isEmpty else { return }
         let currentCount = await memoryQueue.count
-        if currentCount + events.count > maxEventCount {
+        let addedBytes = events.reduce(0) { $0 + Self.estimateEventSize($1) }
+        if currentCount + events.count > maxEventCount || estimatedBytes + addedBytes > maxSizeBytes {
             await flushMemoryToDisk()
         }
         await memoryQueue.requeueToFront(events)
-        for event in events {
-            estimatedBytes += Self.estimateEventSize(event)
-        }
+        estimatedBytes += addedBytes
     }
 
     /// Drop current front batch without requeueing.
@@ -153,8 +149,6 @@ public actor PersistentEventQueue {
         }
     }
 
-    // MARK: - Disk lock (exposed for Dispatcher's drain)
-
     /// Acquire the disk lock. MUST be paired with `releaseDiskLock()`.
     /// Held by `drainDiskStoreToNetwork` for the entire drain duration so that
     /// mid-drain memory flushes do not clobber the drain's remainder write.
@@ -166,8 +160,6 @@ public actor PersistentEventQueue {
     public func releaseDiskLock() async {
         await diskLock.unlock()
     }
-
-    // MARK: - Disk operations
 
     /// Flush the entire memory queue to disk, merging with existing disk contents
     /// and enforcing `maxDiskEvents`. Memory is cleared after a successful write.
@@ -185,11 +177,17 @@ public actor PersistentEventQueue {
 
     /// Drain's single-read primitive. Reads everything from disk and deletes the file
     /// in a single actor hop (no suspends between). Caller MUST hold the disk lock.
-    /// Returns the events that were on disk (possibly empty).
+    /// Events older than `eventTTL` (7 days) are filtered out before returning.
+    /// Returns the live events that were on disk (possibly empty).
     public func readAllFromDiskAndDelete() async -> [EnrichedEventPayload] {
         let snapshot = await diskStore.read()
-        let events = snapshot?.events ?? []
-        if !events.isEmpty {
+        let allEvents = snapshot?.events ?? []
+        let events = Self.filterExpired(allEvents)
+        let dropped = allEvents.count - events.count
+        if dropped > 0 {
+            Logger.log("Drain TTL filter dropped \(dropped) event(s) older than 7 days")
+        }
+        if !allEvents.isEmpty {
             await diskStore.delete()
             _hasDiskData = false
         } else if _hasDiskData {
@@ -234,8 +232,6 @@ public actor PersistentEventQueue {
         return Array(events.prefix(min(count, events.count)))
     }
 
-    // MARK: - Private helpers
-
     /// Internal flush — no lock, caller must hold `diskLock` (or be `flushMemoryToDisk`).
     private func flushMemoryToDiskInternal() async -> Bool {
         let events = await memoryQueue.drain(max: Int.max)
@@ -261,5 +257,15 @@ public actor PersistentEventQueue {
     /// Fast per-event size estimate. Encodes once per event (at enqueue time only).
     private static func estimateEventSize(_ event: EnrichedEventPayload) -> Int {
         (try? jsonEncoder.encode(event))?.count ?? 512
+    }
+
+    /// Drop events whose `timestamp` is older than `eventTTL`. Events without a
+    /// parseable timestamp are kept (conservative — better to send than silently drop).
+    private static func filterExpired(_ events: [EnrichedEventPayload]) -> [EnrichedEventPayload] {
+        let cutoff = Date().addingTimeInterval(-eventTTL)
+        return events.filter { event in
+            guard let ts = DateFormatters.iso8601.date(from: event.timestamp) else { return true }
+            return ts >= cutoff
+        }
     }
 }

--- a/Sources/MetaRouter/queue/PersistentEventQueue.swift
+++ b/Sources/MetaRouter/queue/PersistentEventQueue.swift
@@ -173,8 +173,10 @@ public actor PersistentEventQueue {
     /// and enforcing `maxDiskEvents`. Memory is cleared after a successful write.
     /// Acquires the disk lock — serializes against an in-flight drain.
     /// Returns `true` if at least one event was persisted.
+    /// No-op when `maxDiskEvents == 0` (persistence disabled — memory-only pipeline).
     @discardableResult
     public func flushMemoryToDisk() async -> Bool {
+        guard maxDiskEvents > 0 else { return false }
         await diskLock.lock()
         let result = await flushMemoryToDiskInternal()
         await diskLock.unlock()
@@ -201,7 +203,9 @@ public actor PersistentEventQueue {
     /// Full overwrite of the disk store with the given events.
     /// Used by drain for checkpoints and "write remainder on failure."
     /// Caller MUST hold the disk lock.
+    /// No-op when `maxDiskEvents == 0` (persistence disabled — memory-only pipeline).
     public func writeDiskStore(_ events: [EnrichedEventPayload]) async {
+        guard maxDiskEvents > 0 else { return }
         guard !events.isEmpty else {
             await diskStore.delete()
             _hasDiskData = false

--- a/Sources/MetaRouter/utils/AsyncMutex.swift
+++ b/Sources/MetaRouter/utils/AsyncMutex.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// FIFO async mutex. Used by `PersistentEventQueue` to serialize disk writes
+/// between `flushMemoryToDisk` and the dispatcher's `drainDiskStoreToNetwork`.
+///
+/// Swift actors provide method-level isolation but release the queue across
+/// `await` points, so a drain that suspends for network I/O can be interleaved
+/// with an enqueue-triggered flush. This mutex closes that window.
+final class AsyncMutex: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "metarouter.asyncmutex.state")
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func lock() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            queue.async {
+                if !self.locked {
+                    self.locked = true
+                    cont.resume()
+                } else {
+                    self.waiters.append(cont)
+                }
+            }
+        }
+    }
+
+    func unlock() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            queue.async {
+                if let next = self.waiters.first {
+                    self.waiters.removeFirst()
+                    // Ownership transfers to the resumed waiter; `locked` stays true.
+                    next.resume()
+                } else {
+                    self.locked = false
+                }
+                cont.resume()
+            }
+        }
+    }
+}

--- a/Sources/MetaRouter/utils/DateFormatters.swift
+++ b/Sources/MetaRouter/utils/DateFormatters.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Shared ISO8601 formatter. `ISO8601DateFormatter` is thread-safe for
+/// `string(from:)` / `date(from:)` in practice, so a single static instance
+/// is reused across the SDK instead of allocating one per component.
+enum DateFormatters {
+    nonisolated(unsafe) static let iso8601 = ISO8601DateFormatter()
+}

--- a/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
+++ b/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
@@ -146,11 +146,14 @@ final class DebouncedNetworkMonitorTests: XCTestCase {
         let flushCounter = FlushCounter()
         let options = TestDataFactory.makeInitOptions()
         let networking = CountingNetworking(counter: flushCounter)
+        let diskStore = DiskStorage(baseDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("metarouter-test-\(UUID().uuidString)"))
+        let persistentQueue = PersistentEventQueue(diskStore: diskStore, maxEventCount: 100)
         let dispatcher = Dispatcher(
             options: options,
             http: networking,
             breaker: CircuitBreaker(),
-            queueCapacity: 100
+            persistentQueue: persistentQueue
         )
 
         await dispatcher.offer(makeTestEvent())

--- a/Tests/MetaRouterTests/DispatcherTests.swift
+++ b/Tests/MetaRouterTests/DispatcherTests.swift
@@ -1034,7 +1034,7 @@ final class DispatcherTests: XCTestCase {
         XCTAssertEqual(overflowRemaining.count, 0)
     }
 
-    func testSendBatchDirectReturnsFalseOnError() async {
+    func testSendBatchDirectReturnsNilOnError() async {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
         stub.mode = .error
@@ -1045,10 +1045,10 @@ final class DispatcherTests: XCTestCase {
         )
 
         let result = await dispatcher.sendBatchDirect([makeTestEvent()])
-        XCTAssertFalse(result, "sendBatchDirect should return false on network error")
+        XCTAssertNil(result, "sendBatchDirect should return nil on network error")
     }
 
-    func testSendBatchDirectReturnsTrueOnSuccess() async {
+    func testSendBatchDirectReturnsResponseOnSuccess() async {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
         stub.mode = .success
@@ -1059,8 +1059,24 @@ final class DispatcherTests: XCTestCase {
         )
 
         let result = await dispatcher.sendBatchDirect([makeTestEvent()])
-        XCTAssertTrue(result, "sendBatchDirect should return true on 200")
+        XCTAssertNotNil(result, "sendBatchDirect should return response on 200")
+        XCTAssertEqual(result?.statusCode, 200)
         XCTAssertEqual(stub.callCount, 1)
+    }
+
+    func testSendBatchDirectReturnsResponseOnHttpError() async {
+        let options = TestDataFactory.makeInitOptions()
+        let stub = StubNetworking()
+        stub.mode = .http(500)
+        let dispatcher = Dispatcher(
+            options: options, http: stub,
+            breaker: CircuitBreaker(),
+            queueCapacity: 100
+        )
+
+        let result = await dispatcher.sendBatchDirect([makeTestEvent()])
+        XCTAssertNotNil(result, "sendBatchDirect should return response on HTTP error")
+        XCTAssertEqual(result?.statusCode, 500)
     }
 }
 

--- a/Tests/MetaRouterTests/DispatcherTests.swift
+++ b/Tests/MetaRouterTests/DispatcherTests.swift
@@ -847,6 +847,221 @@ final class DispatcherTests: XCTestCase {
         offline = await dispatcher.getIsOffline()
         XCTAssertFalse(offline)
     }
+
+
+    // MARK: - Offline Overflow Drain Tests
+
+    func testOverflowDrainSendsDirectlyToNetwork() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainDispatcherTest-\(UUID().uuidString)")
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainOverflowTest-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            try? FileManager.default.removeItem(at: overflowDir)
+        }
+
+        // Seed overflow disk with events
+        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
+        let overflowEvents = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
+        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
+
+        let recorder = BatchRecordingNetworking()
+        let persistentQueue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+        let dispatcher = Dispatcher(
+            options: TestDataFactory.makeInitOptions(),
+            http: recorder,
+            breaker: CircuitBreaker(),
+            persistentQueue: persistentQueue
+        )
+
+        // Also add a memory queue event
+        await dispatcher.offer(makeTestEvent(messageId: "memory-0"))
+
+        // Drain overflow
+        await dispatcher.drainOverflowToNetwork()
+
+        // Overflow should have been sent (1 batch of 5)
+        XCTAssertGreaterThanOrEqual(recorder.callCount, 1, "Overflow events should be sent to network")
+
+        // Memory queue event should NOT have been touched by drain
+        let remaining = await dispatcher.getQueueLength()
+        XCTAssertEqual(remaining, 1, "Memory queue should be unaffected by overflow drain")
+
+        // Overflow disk should be cleaned up
+        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowRemaining.count, 0, "Overflow disk should be empty after drain")
+    }
+
+    func testOverflowDrainStopsOnNetworkFailure() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainFailTest-\(UUID().uuidString)")
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainFailOverflow-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            try? FileManager.default.removeItem(at: overflowDir)
+        }
+
+        // Seed overflow disk with events
+        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
+        let overflowEvents = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
+        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
+
+        let stub = StubNetworking()
+        stub.mode = .http(500)  // All requests fail
+
+        let persistentQueue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+        let dispatcher = Dispatcher(
+            options: TestDataFactory.makeInitOptions(),
+            http: stub,
+            breaker: CircuitBreaker(failureThreshold: 10),
+            persistentQueue: persistentQueue
+        )
+
+        await dispatcher.drainOverflowToNetwork()
+
+        // Should have attempted once and stopped
+        XCTAssertEqual(stub.callCount, 1, "Should stop draining after first failure")
+
+        // Events should still be on disk
+        let remaining = await persistentQueue.readOverflowBatch(max: 100)
+        XCTAssertEqual(remaining.count, 5, "All overflow events should remain on disk after failure")
+    }
+
+    func testOfflineToOnlineTriggersOverflowDrain() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OnlineDrainTest-\(UUID().uuidString)")
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OnlineDrainOverflow-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            try? FileManager.default.removeItem(at: overflowDir)
+        }
+
+        let recorder = BatchRecordingNetworking()
+        let persistentQueue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+        let dispatcher = Dispatcher(
+            options: TestDataFactory.makeInitOptions(),
+            http: recorder,
+            breaker: CircuitBreaker(),
+            persistentQueue: persistentQueue
+        )
+
+        // Go offline and overflow events
+        await dispatcher.setOffline(true)
+        for i in 0..<6 {
+            await dispatcher.offer(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // Memory should have 3, overflow should have 3
+        let memCount = await dispatcher.getQueueLength()
+        XCTAssertEqual(memCount, 3)
+
+        // Come back online — triggers flush + drain
+        await dispatcher.setOffline(false)
+
+        // Give Tasks time to complete
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        // Both memory queue AND overflow should be drained
+        let remaining = await dispatcher.getQueueLength()
+        XCTAssertEqual(remaining, 0, "Memory queue should be empty after reconnect")
+
+        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowRemaining.count, 0, "Overflow disk should be empty after reconnect")
+
+        // HTTP calls should have been made
+        XCTAssertGreaterThanOrEqual(recorder.callCount, 1, "Events should have been sent to network")
+    }
+
+    func testOverflowEventsDoNotEnterMemoryQueue() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NoRehydrateTest-\(UUID().uuidString)")
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NoRehydrateOverflow-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+            try? FileManager.default.removeItem(at: overflowDir)
+        }
+
+        // Seed overflow disk with 200 events
+        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
+        let overflowEvents = (0..<200).map { makeTestEvent(messageId: "overflow-\($0)") }
+        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
+
+        let recorder = BatchRecordingNetworking()
+        let persistentQueue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 50, // memory cap is only 50
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+        let dispatcher = Dispatcher(
+            options: TestDataFactory.makeInitOptions(),
+            http: recorder,
+            breaker: CircuitBreaker(),
+            persistentQueue: persistentQueue
+        )
+
+        // Drain overflow
+        await dispatcher.drainOverflowToNetwork()
+
+        // Memory queue should still be empty — overflow goes direct to network
+        let memCount = await dispatcher.getQueueLength()
+        XCTAssertEqual(memCount, 0, "Overflow events should not load into memory queue")
+
+        // All 200 events should have been sent via HTTP (2 batches of 100)
+        XCTAssertEqual(recorder.callCount, 2, "200 events should be sent in 2 batches of 100")
+
+        // Overflow disk should be cleaned up
+        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 1000)
+        XCTAssertEqual(overflowRemaining.count, 0)
+    }
+
+    func testSendBatchDirectReturnsFalseOnError() async {
+        let options = TestDataFactory.makeInitOptions()
+        let stub = StubNetworking()
+        stub.mode = .error
+        let dispatcher = Dispatcher(
+            options: options, http: stub,
+            breaker: CircuitBreaker(),
+            queueCapacity: 100
+        )
+
+        let result = await dispatcher.sendBatchDirect([makeTestEvent()])
+        XCTAssertFalse(result, "sendBatchDirect should return false on network error")
+    }
+
+    func testSendBatchDirectReturnsTrueOnSuccess() async {
+        let options = TestDataFactory.makeInitOptions()
+        let stub = StubNetworking()
+        stub.mode = .success
+        let dispatcher = Dispatcher(
+            options: options, http: stub,
+            breaker: CircuitBreaker(),
+            queueCapacity: 100
+        )
+
+        let result = await dispatcher.sendBatchDirect([makeTestEvent()])
+        XCTAssertTrue(result, "sendBatchDirect should return true on 200")
+        XCTAssertEqual(stub.callCount, 1)
+    }
 }
 
 

--- a/Tests/MetaRouterTests/DispatcherTests.swift
+++ b/Tests/MetaRouterTests/DispatcherTests.swift
@@ -41,6 +41,36 @@ private final class StubNetworking: Networking, @unchecked Sendable {
     }
 }
 
+/// Builds a `Dispatcher` backed by a throwaway temp-dir disk store for tests.
+/// Accepts either `queueCapacity:` (helper builds the queue) or `persistentQueue:` (caller builds it).
+private func makeDispatcher(
+    options: InitOptions,
+    http: Networking = NetworkClient(),
+    breaker: CircuitBreaker = CircuitBreaker(),
+    queueCapacity: Int? = nil,
+    persistentQueue: PersistentEventQueue? = nil,
+    config: Dispatcher.Config = Dispatcher.Config(),
+    onFatalConfigError: Dispatcher.FatalConfigHandler? = nil
+) -> Dispatcher {
+    let queue: PersistentEventQueue
+    if let pq = persistentQueue {
+        queue = pq
+    } else {
+        let cap = queueCapacity ?? 2000
+        let diskStore = DiskStorage(baseDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("metarouter-test-\(UUID().uuidString)"))
+        queue = PersistentEventQueue(diskStore: diskStore, maxEventCount: cap)
+    }
+    return Dispatcher(
+        options: options,
+        http: http,
+        breaker: breaker,
+        persistentQueue: queue,
+        config: config,
+        onFatalConfigError: onFatalConfigError
+    )
+}
+
 /// Creates a minimal enriched event for testing
 private func makeTestEvent(messageId: String = "mid") -> EnrichedEventPayload {
     let ctx = EventContext(
@@ -65,7 +95,7 @@ final class DispatcherTests: XCTestCase {
     func testFlushSuccessRemovesBatch() async throws {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
 
         await dispatcher.offer(makeTestEvent())
         await dispatcher.flush()
@@ -79,7 +109,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(401)
         let statusHolder = StatusHolder()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 10, onFatalConfigError: { status in statusHolder.value = status })
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 10, onFatalConfigError: { status in statusHolder.value = status })
 
         await dispatcher.offer(makeTestEvent())
         await dispatcher.flush()
@@ -90,7 +120,7 @@ final class DispatcherTests: XCTestCase {
     func testTracingDisabledByDefault() async throws {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
 
         await dispatcher.offer(makeTestEvent())
         await dispatcher.flush()
@@ -101,7 +131,7 @@ final class DispatcherTests: XCTestCase {
     func testTracingEnabledAddsHeader() async throws {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
 
         await dispatcher.setTracing(true)
         await dispatcher.offer(makeTestEvent())
@@ -114,7 +144,7 @@ final class DispatcherTests: XCTestCase {
     func testTracingCanBeDisabled() async throws {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
 
         await dispatcher.setTracing(true)
         await dispatcher.offer(makeTestEvent())
@@ -135,7 +165,7 @@ final class DispatcherTests: XCTestCase {
     func testTracingPersistsAcrossMultipleFlushes() async throws {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
+        let dispatcher = makeDispatcher(options: options, http: stub, breaker: CircuitBreaker(), queueCapacity: 100)
 
         await dispatcher.setTracing(true)
 
@@ -155,7 +185,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(403)
         let statusHolder = StatusHolder()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub, breaker: CircuitBreaker(),
             queueCapacity: 10,
             onFatalConfigError: { status in statusHolder.value = status }
@@ -174,7 +204,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(404)
         let statusHolder = StatusHolder()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub, breaker: CircuitBreaker(),
             queueCapacity: 10,
             onFatalConfigError: { status in statusHolder.value = status }
@@ -193,7 +223,7 @@ final class DispatcherTests: XCTestCase {
 
         // First call returns 413, then subsequent calls succeed
         let sequencer = CallSequencer(responses: [.http(413), .success])
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: sequencer,
             breaker: CircuitBreaker(failureThreshold: 10), // high threshold so breaker doesn't trip
             queueCapacity: 100,
@@ -219,7 +249,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(500)
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000), // trip immediately, long cooldown
             queueCapacity: 100
@@ -238,7 +268,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .httpWithHeaders(429, ["Retry-After": "2"])
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000),
             queueCapacity: 100
@@ -257,7 +287,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(408)
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000),
             queueCapacity: 100
@@ -275,7 +305,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(400)
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -293,7 +323,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .http(422)
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -311,7 +341,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .error
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000),
             queueCapacity: 100
@@ -329,7 +359,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .success
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -350,7 +380,7 @@ final class DispatcherTests: XCTestCase {
 
         // Sequence: 413 → 200 → 200 → 200 (batch size: 4 → 2 → 4 on recovery)
         let sequencer = CallSequencer(responses: [.http(413), .success, .success, .success, .success])
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: sequencer,
             breaker: CircuitBreaker(failureThreshold: 10),
             queueCapacity: 100,
@@ -383,7 +413,7 @@ final class DispatcherTests: XCTestCase {
 
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options,
             http: stub,
             breaker: CircuitBreaker(),
@@ -420,7 +450,7 @@ final class DispatcherTests: XCTestCase {
         )
         _ = await queue.checkForPersistedEvents()
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: recorder,
             breaker: CircuitBreaker(),
@@ -453,7 +483,7 @@ final class DispatcherTests: XCTestCase {
         )
         _ = await queue.checkForPersistedEvents()
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: recorder,
             breaker: CircuitBreaker(),
@@ -480,7 +510,7 @@ final class DispatcherTests: XCTestCase {
         // when events exceed maxBatchSize without rehydration
         let options = TestDataFactory.makeInitOptions()
         let recorder = BatchRecordingNetworking()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options,
             http: recorder,
             breaker: CircuitBreaker(),
@@ -519,7 +549,7 @@ final class DispatcherTests: XCTestCase {
         stub.mode = .error
 
         // Default circuit breaker: threshold 3 — circuit stays closed after 1 failure
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100,
@@ -544,7 +574,7 @@ final class DispatcherTests: XCTestCase {
         let options = TestDataFactory.makeInitOptions()
         let sequencer = CallSequencer(responses: [.error, .success])
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: sequencer,
             breaker: CircuitBreaker(),
             queueCapacity: 100,
@@ -569,7 +599,7 @@ final class DispatcherTests: XCTestCase {
         // Sequence: error → success (retry recovers), then error again on next flush
         let sequencer = CallSequencer(responses: [.error, .success, .error, .success])
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: sequencer,
             breaker: CircuitBreaker(failureThreshold: 10), // high threshold to avoid circuit opening
             queueCapacity: 100,
@@ -608,7 +638,7 @@ final class DispatcherTests: XCTestCase {
         stub.mode = .http(503)
 
         // Default circuit breaker: stays closed after 1 failure
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100,
@@ -632,7 +662,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .success
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100,
@@ -665,7 +695,7 @@ final class DispatcherTests: XCTestCase {
             diskStore: DiskStorage(baseDirectory: tempDir),
             maxEventCount: 100
         )
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: stub,
             breaker: CircuitBreaker(),
@@ -693,7 +723,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .success
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -722,7 +752,7 @@ final class DispatcherTests: XCTestCase {
         stub.mode = .http(500)
 
         let breaker = CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000, jitterRatio: 0.0)
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: breaker,
             queueCapacity: 100
@@ -752,7 +782,7 @@ final class DispatcherTests: XCTestCase {
         stub.mode = .http(500)
 
         let breaker = CircuitBreaker(failureThreshold: 1, cooldownMs: 60_000, jitterRatio: 0.0)
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: breaker,
             queueCapacity: 100
@@ -772,7 +802,7 @@ final class DispatcherTests: XCTestCase {
         let stub = StubNetworking()
         stub.mode = .success
 
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -802,7 +832,7 @@ final class DispatcherTests: XCTestCase {
     func testGetIsOfflineReflectsState() async {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -821,7 +851,6 @@ final class DispatcherTests: XCTestCase {
     }
 
 
-    // MARK: - Disk store drain tests
 
     /// Helper: seed a disk store and build a dispatcher wired to it.
     private func makeDrainFixture(
@@ -840,7 +869,7 @@ final class DispatcherTests: XCTestCase {
             maxEventCount: 100
         )
         _ = await queue.checkForPersistedEvents()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: http,
             breaker: breaker,
@@ -963,7 +992,7 @@ final class DispatcherTests: XCTestCase {
 
         let queue = PersistentEventQueue(diskStore: DiskStorage(baseDirectory: tempDir), maxEventCount: 100)
         _ = await queue.checkForPersistedEvents()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: stub,
             breaker: CircuitBreaker(failureThreshold: 10),
@@ -1056,7 +1085,7 @@ final class DispatcherTests: XCTestCase {
 
         let queue = PersistentEventQueue(diskStore: DiskStorage(baseDirectory: diskDir), maxEventCount: 100)
         _ = await queue.checkForPersistedEvents()
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: sequencer,
             breaker: CircuitBreaker(failureThreshold: 100),
@@ -1079,7 +1108,7 @@ final class DispatcherTests: XCTestCase {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
         stub.mode = .error
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -1093,7 +1122,7 @@ final class DispatcherTests: XCTestCase {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
         stub.mode = .success
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100
@@ -1109,7 +1138,7 @@ final class DispatcherTests: XCTestCase {
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
         stub.mode = .http(500)
-        let dispatcher = Dispatcher(
+        let dispatcher = makeDispatcher(
             options: options, http: stub,
             breaker: CircuitBreaker(),
             queueCapacity: 100

--- a/Tests/MetaRouterTests/DispatcherTests.swift
+++ b/Tests/MetaRouterTests/DispatcherTests.swift
@@ -376,11 +376,10 @@ final class DispatcherTests: XCTestCase {
         XCTAssertEqual(remaining, 0, "All events should drain after batch size recovery")
     }
 
-    func testFlushToDiskDelegatesToQueue() async throws {
+    func testFlushToDiskDelegatesToQueue() async {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("DispatcherDiskTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
-
 
         let options = TestDataFactory.makeInitOptions()
         let stub = StubNetworking()
@@ -389,129 +388,91 @@ final class DispatcherTests: XCTestCase {
             http: stub,
             breaker: CircuitBreaker(),
             persistentQueue: PersistentEventQueue(
-                diskStorage: DiskStorage(baseDirectory: tempDir),
+                diskStore: DiskStorage(baseDirectory: tempDir),
                 maxEventCount: 100
             )
         )
 
         await dispatcher.offer(makeTestEvent(messageId: "disk-test"))
-        try await dispatcher.flushToDisk()
+        await dispatcher.flushToDisk()
 
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = await diskStorage.read()
+        let diskStore = DiskStorage(baseDirectory: tempDir)
+        let snapshot = await diskStore.read()
         XCTAssertEqual(snapshot?.events.count, 1)
         XCTAssertEqual(snapshot?.events[0].messageId, "disk-test")
     }
 
 
-    func testRehydratedEventsFlushInMultipleBatches() async throws {
+    func testDiskDrainSendsInBatchesOfInitialMaxBatchSize() async throws {
         let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("RehydrationBatchTest-\(UUID().uuidString)")
+            .appendingPathComponent("DrainBatchTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        // Seed disk with 250 events
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let events = (0..<250).map { makeTestEvent(messageId: "rehydrated-\($0)") }
-        let snapshot = QueueSnapshot(events: events)
-        try await diskStorage.write(snapshot)
+        // Seed disk with 250 events; drain should send them in 3 batches (100, 100, 50)
+        let diskStore = DiskStorage(baseDirectory: tempDir)
+        let events = (0..<250).map { makeTestEvent(messageId: "persisted-\($0)") }
+        try await diskStore.write(QueueSnapshot(events: events))
 
         let recorder = BatchRecordingNetworking()
+        let queue = PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 2000
+        )
+        _ = await queue.checkForPersistedEvents()
+
         let dispatcher = Dispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: recorder,
             breaker: CircuitBreaker(),
-            persistentQueue: PersistentEventQueue(
-                diskStorage: DiskStorage(baseDirectory: tempDir),
-                maxEventCount: 2000
-            ),
+            persistentQueue: queue,
             config: Dispatcher.Config(initialMaxBatchSize: 100)
         )
 
-        let rehydrated = await dispatcher.rehydrate()
-        XCTAssertEqual(rehydrated, 250)
+        await dispatcher.drainDiskStoreToNetwork()
 
-        await dispatcher.flush()
-
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 0, "All rehydrated events should be drained")
+        let memCount = await dispatcher.getQueueLength()
+        XCTAssertEqual(memCount, 0, "Drain must not load events into memory")
         XCTAssertEqual(recorder.callCount, 3, "250 events with batchSize=100 should take 3 API calls")
-
-        let batchSizes = recorder.batchSizes
-        XCTAssertEqual(batchSizes, [100, 100, 50], "Batches should be 100, 100, 50")
+        XCTAssertEqual(recorder.batchSizes, [100, 100, 50])
     }
 
-    func testRehydratedEventsPlusNewEventsAllDrainInSingleFlush() async throws {
+    func testDiskDrainDoesNotInterfereWithNewMemoryEvents() async throws {
         let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("RehydrationPlusNewTest-\(UUID().uuidString)")
+            .appendingPathComponent("DrainPlusNewTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        // Seed disk with 5 events
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let diskEvents = (0..<5).map { makeTestEvent(messageId: "rehydrated-\($0)") }
-        try await diskStorage.write(QueueSnapshot(events: diskEvents))
+        // Seed 5 events on disk
+        let diskStore = DiskStorage(baseDirectory: tempDir)
+        let diskEvents = (0..<5).map { makeTestEvent(messageId: "disk-\($0)") }
+        try await diskStore.write(QueueSnapshot(events: diskEvents))
 
         let recorder = BatchRecordingNetworking()
+        let queue = PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 2000
+        )
+        _ = await queue.checkForPersistedEvents()
+
         let dispatcher = Dispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: recorder,
             breaker: CircuitBreaker(),
-            persistentQueue: PersistentEventQueue(
-                diskStorage: DiskStorage(baseDirectory: tempDir),
-                maxEventCount: 2000
-            ),
-            config: Dispatcher.Config(initialMaxBatchSize: 100)
+            persistentQueue: queue,
+            config: Dispatcher.Config(autoFlushThreshold: 1000, initialMaxBatchSize: 100)
         )
 
-        let rehydrated = await dispatcher.rehydrate()
-        XCTAssertEqual(rehydrated, 5)
-
-        // Add new events after rehydration (before flush)
+        // Add 3 events to memory, then drain disk — memory events should stay put
         for i in 0..<3 {
-            await dispatcher.offer(makeTestEvent(messageId: "new-\(i)"))
+            await dispatcher.offer(makeTestEvent(messageId: "mem-\(i)"))
         }
 
-        await dispatcher.flush()
+        await dispatcher.drainDiskStoreToNetwork()
 
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 0, "All events (rehydrated + new) should be drained")
-        XCTAssertEqual(recorder.callCount, 1, "8 events should fit in a single batch")
-
-        let batchSizes = recorder.batchSizes
-        XCTAssertEqual(batchSizes, [8], "All 8 events should be in one batch")
-    }
-
-    func testRehydrationOverCapacityDropsOldestAndFlushesRemainder() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("RehydrationOverCapTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
-        // Seed disk with 150 events, but queue capacity is only 50
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let events = (0..<150).map { makeTestEvent(messageId: "evt-\($0)") }
-        try await diskStorage.write(QueueSnapshot(events: events))
-
-        let recorder = BatchRecordingNetworking()
-        let dispatcher = Dispatcher(
-            options: TestDataFactory.makeInitOptions(),
-            http: recorder,
-            breaker: CircuitBreaker(),
-            persistentQueue: PersistentEventQueue(
-                diskStorage: DiskStorage(baseDirectory: tempDir),
-                maxEventCount: 50
-            ),
-            config: Dispatcher.Config(initialMaxBatchSize: 25)
-        )
-
-        let rehydrated = await dispatcher.rehydrate()
-        // Should cap at 50, dropping the 100 oldest
-        XCTAssertEqual(rehydrated, 50, "Rehydration should cap at maxEventCount")
-
-        await dispatcher.flush()
-
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 0, "All capped events should be drained")
-        XCTAssertEqual(recorder.callCount, 2, "50 events with batchSize=25 should take 2 API calls")
-        XCTAssertEqual(recorder.batchSizes, [25, 25])
+        // Disk events sent via drain; memory events still queued for the regular flush
+        XCTAssertEqual(recorder.callCount, 1, "Disk drain sends 5 events in one batch")
+        XCTAssertEqual(recorder.batchSizes, [5])
+        let memCount = await dispatcher.getQueueLength()
+        XCTAssertEqual(memCount, 3, "Memory queue untouched by drain")
     }
 
     func testProcessUntilEmptyDrainsAcrossBatchBoundary() async throws {
@@ -693,14 +654,22 @@ final class DispatcherTests: XCTestCase {
 
 
     func testEventsEnqueueWhileOfflineNoHttpAttempts() async {
-        let options = TestDataFactory.makeInitOptions()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OfflineEnqueueTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
         let stub = StubNetworking()
         stub.mode = .success
 
+        let queue = PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100
+        )
         let dispatcher = Dispatcher(
-            options: options, http: stub,
+            options: TestDataFactory.makeInitOptions(),
+            http: stub,
             breaker: CircuitBreaker(),
-            queueCapacity: 100
+            persistentQueue: queue
         )
 
         await dispatcher.setOffline(true)
@@ -712,8 +681,11 @@ final class DispatcherTests: XCTestCase {
         await dispatcher.flush()
 
         XCTAssertEqual(stub.callCount, 0, "No HTTP attempts should be made while offline")
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 5, "All events should remain queued while offline")
+
+        // Offline flush moves memory to disk — no events lost.
+        let memCount = await dispatcher.getQueueLength()
+        let onDisk = await queue.readDiskBatch(max: 100)
+        XCTAssertEqual(memCount + onDisk.count, 5, "All events preserved across memory + disk while offline")
     }
 
     func testOfflineToOnlineTriggersFlush() async {
@@ -849,189 +821,258 @@ final class DispatcherTests: XCTestCase {
     }
 
 
-    // MARK: - Offline Overflow Drain Tests
+    // MARK: - Disk store drain tests
 
-    func testOverflowDrainSendsDirectlyToNetwork() async throws {
+    /// Helper: seed a disk store and build a dispatcher wired to it.
+    private func makeDrainFixture(
+        seed: [EnrichedEventPayload],
+        http: Networking,
+        breaker: CircuitBreaker = CircuitBreaker(failureThreshold: 10),
+        config: Dispatcher.Config = Dispatcher.Config(initialMaxBatchSize: 100)
+    ) async throws -> (dispatcher: Dispatcher, queue: PersistentEventQueue, tempDir: URL) {
         let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DrainDispatcherTest-\(UUID().uuidString)")
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DrainOverflowTest-\(UUID().uuidString)")
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-            try? FileManager.default.removeItem(at: overflowDir)
+            .appendingPathComponent("DrainFixture-\(UUID().uuidString)")
+        if !seed.isEmpty {
+            try await DiskStorage(baseDirectory: tempDir).write(QueueSnapshot(events: seed))
         }
-
-        // Seed overflow disk with events
-        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
-        let overflowEvents = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
-        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
-
-        let recorder = BatchRecordingNetworking()
-        let persistentQueue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 100,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
+        let queue = PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100
         )
+        _ = await queue.checkForPersistedEvents()
         let dispatcher = Dispatcher(
             options: TestDataFactory.makeInitOptions(),
-            http: recorder,
-            breaker: CircuitBreaker(),
-            persistentQueue: persistentQueue
+            http: http,
+            breaker: breaker,
+            persistentQueue: queue,
+            config: config
         )
-
-        // Also add a memory queue event
-        await dispatcher.offer(makeTestEvent(messageId: "memory-0"))
-
-        // Drain overflow
-        await dispatcher.drainOverflowToNetwork()
-
-        // Overflow should have been sent (1 batch of 5)
-        XCTAssertGreaterThanOrEqual(recorder.callCount, 1, "Overflow events should be sent to network")
-
-        // Memory queue event should NOT have been touched by drain
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 1, "Memory queue should be unaffected by overflow drain")
-
-        // Overflow disk should be cleaned up
-        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowRemaining.count, 0, "Overflow disk should be empty after drain")
+        return (dispatcher, queue, tempDir)
     }
 
-    func testOverflowDrainStopsOnNetworkFailure() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DrainFailTest-\(UUID().uuidString)")
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DrainFailOverflow-\(UUID().uuidString)")
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-            try? FileManager.default.removeItem(at: overflowDir)
-        }
+    func testDiskDrainSendsAllEventsAndClearsFile() async throws {
+        let seed = (0..<5).map { makeTestEvent(messageId: "persisted-\($0)") }
+        let recorder = BatchRecordingNetworking()
+        let fixture = try await makeDrainFixture(seed: seed, http: recorder)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
 
-        // Seed overflow disk with events
-        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
-        let overflowEvents = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
-        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
+        // Memory queue event should be untouched by drain
+        await fixture.dispatcher.offer(makeTestEvent(messageId: "memory-0"))
 
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(recorder.callCount, 1)
+        XCTAssertEqual(recorder.batchSizes, [5])
+
+        let memCount = await fixture.dispatcher.getQueueLength()
+        XCTAssertEqual(memCount, 1, "Memory queue untouched by drain")
+
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty, "Disk file should be cleared after successful drain")
+    }
+
+    func testDiskDrainStopsOnServerErrorAndPersistsRemainder() async throws {
+        let seed = (0..<5).map { makeTestEvent(messageId: "persisted-\($0)") }
         let stub = StubNetworking()
-        stub.mode = .http(500)  // All requests fail
+        stub.mode = .http(500)
+        let fixture = try await makeDrainFixture(seed: seed, http: stub)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
 
-        let persistentQueue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 100,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(stub.callCount, 1, "Drain should stop after first 500")
+
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertEqual(onDisk.count, 5, "All events persisted back to disk on server-error halt")
+    }
+
+    func testDiskDrainStopsOn429AndPersistsRemainder() async throws {
+        let seed = (0..<5).map { makeTestEvent(messageId: "persisted-\($0)") }
+        let stub = StubNetworking()
+        stub.mode = .http(429)
+        let fixture = try await makeDrainFixture(seed: seed, http: stub)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(stub.callCount, 1)
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertEqual(onDisk.count, 5)
+    }
+
+    func testDiskDrainStopsOnNetworkFailureAndPersistsRemainder() async throws {
+        let seed = (0..<5).map { makeTestEvent(messageId: "persisted-\($0)") }
+        let stub = StubNetworking()
+        stub.mode = .error
+        let fixture = try await makeDrainFixture(seed: seed, http: stub)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(stub.callCount, 1)
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertEqual(onDisk.count, 5)
+    }
+
+    func testDiskDrain413HalvesBatchSize() async throws {
+        let seed = (0..<4).map { makeTestEvent(messageId: "persisted-\($0)") }
+        // First call returns 413, subsequent calls succeed
+        let sequencer = CallSequencer(responses: [.http(413), .success, .success, .success])
+        let fixture = try await makeDrainFixture(
+            seed: seed,
+            http: sequencer,
+            config: Dispatcher.Config(initialMaxBatchSize: 4)
         )
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        // Should retry with smaller batches (2, 2) after 413 halves the size from 4
+        XCTAssertGreaterThanOrEqual(sequencer.callCount, 2)
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty, "All events should drain across halved batches")
+    }
+
+    func testDiskDrain413DropsSingleOversizedEvent() async throws {
+        let seed = [makeTestEvent(messageId: "oversize")]
+        let stub = StubNetworking()
+        stub.mode = .http(413)
+        let fixture = try await makeDrainFixture(
+            seed: seed,
+            http: stub,
+            config: Dispatcher.Config(initialMaxBatchSize: 1)
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty, "Oversize event at batchSize=1 should be dropped")
+    }
+
+    func testDiskDrainFatalConfigDeletesStoreAndFiresHandler() async throws {
+        let seed = (0..<3).map { makeTestEvent(messageId: "persisted-\($0)") }
+        let stub = StubNetworking()
+        stub.mode = .http(401)
+        let status = StatusHolder()
+
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainFatalTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try await DiskStorage(baseDirectory: tempDir).write(QueueSnapshot(events: seed))
+
+        let queue = PersistentEventQueue(diskStore: DiskStorage(baseDirectory: tempDir), maxEventCount: 100)
+        _ = await queue.checkForPersistedEvents()
         let dispatcher = Dispatcher(
             options: TestDataFactory.makeInitOptions(),
             http: stub,
             breaker: CircuitBreaker(failureThreshold: 10),
-            persistentQueue: persistentQueue
+            persistentQueue: queue,
+            onFatalConfigError: { code in status.value = code }
         )
 
-        await dispatcher.drainOverflowToNetwork()
+        await dispatcher.drainDiskStoreToNetwork()
 
-        // Should have attempted once and stopped
-        XCTAssertEqual(stub.callCount, 1, "Should stop draining after first failure")
-
-        // Events should still be on disk
-        let remaining = await persistentQueue.readOverflowBatch(max: 100)
-        XCTAssertEqual(remaining.count, 5, "All overflow events should remain on disk after failure")
+        XCTAssertEqual(status.value, 401, "FATAL_CONFIG handler must fire from drain path")
+        let onDisk = await queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty, "Disk store deleted on fatal config")
     }
 
-    func testOfflineToOnlineTriggersOverflowDrain() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OnlineDrainTest-\(UUID().uuidString)")
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OnlineDrainOverflow-\(UUID().uuidString)")
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-            try? FileManager.default.removeItem(at: overflowDir)
-        }
-
-        let recorder = BatchRecordingNetworking()
-        let persistentQueue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
+    func testDiskDrainClientErrorDropsBatchAndContinues() async throws {
+        let seed = (0..<6).map { makeTestEvent(messageId: "persisted-\($0)") }
+        // First 3 events → 400 (drop). Next 3 → 200.
+        let sequencer = CallSequencer(responses: [.http(400), .success])
+        let fixture = try await makeDrainFixture(
+            seed: seed,
+            http: sequencer,
+            config: Dispatcher.Config(initialMaxBatchSize: 3)
         )
-        let dispatcher = Dispatcher(
-            options: TestDataFactory.makeInitOptions(),
-            http: recorder,
-            breaker: CircuitBreaker(),
-            persistentQueue: persistentQueue
-        )
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
 
-        // Go offline and overflow events
-        await dispatcher.setOffline(true)
-        for i in 0..<6 {
-            await dispatcher.offer(makeTestEvent(messageId: "e\(i)"))
-        }
+        await fixture.dispatcher.drainDiskStoreToNetwork()
 
-        // Memory should have 3, overflow should have 3
-        let memCount = await dispatcher.getQueueLength()
-        XCTAssertEqual(memCount, 3)
-
-        // Come back online — triggers flush + drain
-        await dispatcher.setOffline(false)
-
-        // Give Tasks time to complete
-        try? await Task.sleep(nanoseconds: 300_000_000)
-
-        // Both memory queue AND overflow should be drained
-        let remaining = await dispatcher.getQueueLength()
-        XCTAssertEqual(remaining, 0, "Memory queue should be empty after reconnect")
-
-        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowRemaining.count, 0, "Overflow disk should be empty after reconnect")
-
-        // HTTP calls should have been made
-        XCTAssertGreaterThanOrEqual(recorder.callCount, 1, "Events should have been sent to network")
+        XCTAssertEqual(sequencer.callCount, 2, "Second batch should proceed after first is dropped")
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty, "Disk empty after bad batch drop + good batch success")
     }
 
-    func testOverflowEventsDoNotEnterMemoryQueue() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("NoRehydrateTest-\(UUID().uuidString)")
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("NoRehydrateOverflow-\(UUID().uuidString)")
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-            try? FileManager.default.removeItem(at: overflowDir)
-        }
-
-        // Seed overflow disk with 200 events
-        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
-        let overflowEvents = (0..<200).map { makeTestEvent(messageId: "overflow-\($0)") }
-        try await overflowDisk.write(QueueSnapshot(events: overflowEvents))
-
+    func testDiskDrainConcurrentCallsGuarded() async throws {
+        let seed = (0..<10).map { makeTestEvent(messageId: "persisted-\($0)") }
         let recorder = BatchRecordingNetworking()
-        let persistentQueue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 50, // memory cap is only 50
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
+        let fixture = try await makeDrainFixture(
+            seed: seed,
+            http: recorder,
+            config: Dispatcher.Config(initialMaxBatchSize: 10)
         )
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        // Kick off two drains concurrently
+        let dispatcher = fixture.dispatcher
+        async let a: () = dispatcher.drainDiskStoreToNetwork()
+        async let b: () = dispatcher.drainDiskStoreToNetwork()
+        _ = await (a, b)
+
+        // Only one drain should actually have run
+        XCTAssertEqual(recorder.callCount, 1, "Concurrent drain calls must be guarded — only one should actually drain")
+        XCTAssertEqual(recorder.batchSizes, [10])
+    }
+
+    func testDiskDrainSkipsWhenNoPersistedData() async throws {
+        let recorder = BatchRecordingNetworking()
+        let fixture = try await makeDrainFixture(seed: [], http: recorder)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(recorder.callCount, 0, "No network calls when hasDiskData is false")
+    }
+
+    func testDiskDrainSkipsWhenOffline() async throws {
+        let seed = (0..<5).map { makeTestEvent(messageId: "persisted-\($0)") }
+        let recorder = BatchRecordingNetworking()
+        let fixture = try await makeDrainFixture(seed: seed, http: recorder)
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        await fixture.dispatcher.setOffline(true)
+        await fixture.dispatcher.drainDiskStoreToNetwork()
+
+        XCTAssertEqual(recorder.callCount, 0, "Drain must not call network while offline")
+        let onDisk = await fixture.queue.readDiskBatch(max: 100)
+        XCTAssertEqual(onDisk.count, 5, "Events must remain on disk when drain skipped")
+    }
+
+    func testDiskDrainCheckpointEvery10Batches() async throws {
+        // 15 events at batchSize=1 → 15 batches. Checkpoint fires after batch 10.
+        // We inspect disk state at the START of call 11 — after the post-batch-10
+        // checkpoint has had a chance to land on disk.
+        let seed = (0..<15).map { makeTestEvent(messageId: "p-\($0)") }
+        let diskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainCheckpointTest-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: diskDir, withIntermediateDirectories: true)
+        try await DiskStorage(baseDirectory: diskDir).write(QueueSnapshot(events: seed))
+        defer { try? FileManager.default.removeItem(at: diskDir) }
+
+        let sequencer = CheckpointInspectingNetworking(inspectAtCall: 11, diskDir: diskDir)
+
+        let queue = PersistentEventQueue(diskStore: DiskStorage(baseDirectory: diskDir), maxEventCount: 100)
+        _ = await queue.checkForPersistedEvents()
         let dispatcher = Dispatcher(
             options: TestDataFactory.makeInitOptions(),
-            http: recorder,
-            breaker: CircuitBreaker(),
-            persistentQueue: persistentQueue
+            http: sequencer,
+            breaker: CircuitBreaker(failureThreshold: 100),
+            persistentQueue: queue,
+            config: Dispatcher.Config(initialMaxBatchSize: 1)
         )
 
-        // Drain overflow
-        await dispatcher.drainOverflowToNetwork()
+        await dispatcher.drainDiskStoreToNetwork()
 
-        // Memory queue should still be empty — overflow goes direct to network
-        let memCount = await dispatcher.getQueueLength()
-        XCTAssertEqual(memCount, 0, "Overflow events should not load into memory queue")
+        // Drain completes, disk is empty
+        let onDisk = await queue.readDiskBatch(max: 100)
+        XCTAssertTrue(onDisk.isEmpty)
 
-        // All 200 events should have been sent via HTTP (2 batches of 100)
-        XCTAssertEqual(recorder.callCount, 2, "200 events should be sent in 2 batches of 100")
-
-        // Overflow disk should be cleaned up
-        let overflowRemaining = await persistentQueue.readOverflowBatch(max: 1000)
-        XCTAssertEqual(overflowRemaining.count, 0)
+        // Checkpoint wrote (15 - 10 = 5) events remaining to disk after batch 10
+        XCTAssertEqual(sequencer.capturedAtInspection, 5,
+            "Checkpoint after 10 successful batches should leave 5 events on disk")
     }
 
     func testSendBatchDirectReturnsNilOnError() async {
@@ -1114,6 +1155,37 @@ private final class BatchRecordingNetworking: Networking, @unchecked Sendable {
     }
 
     private struct AnyCodableElement: Decodable {}
+}
+
+
+/// Always responds 200. At call number `inspectAtCall`, reads disk state at the top of
+/// the call — used to verify that `drainDiskStoreToNetwork` writes a checkpoint every 10
+/// successful batches (inspect at call 11 to see state after the checkpoint post-batch-10).
+private final class CheckpointInspectingNetworking: Networking, @unchecked Sendable {
+    let inspectAtCall: Int
+    let diskDir: URL
+    private let lock = NSLock()
+    private var _callCount = 0
+    private(set) var capturedAtInspection: Int = -1
+
+    init(inspectAtCall: Int, diskDir: URL) {
+        self.inspectAtCall = inspectAtCall
+        self.diskDir = diskDir
+    }
+
+    func postJSON(url: URL, body: Data, timeoutMs: Int, additionalHeaders: [String: String]?) async throws -> NetworkResponse {
+        let count: Int = lock.withLock {
+            _callCount += 1
+            return _callCount
+        }
+        if count == inspectAtCall {
+            let snapshot = await DiskStorage(baseDirectory: diskDir).read()
+            capturedAtInspection = snapshot?.events.count ?? 0
+        }
+        return NetworkResponse(statusCode: 200, headers: [:], body: Data())
+    }
+
+    func parseRetryAfterMs(from headers: [String: String]) -> Int? { nil }
 }
 
 

--- a/Tests/MetaRouterTests/InitOptionsTests.swift
+++ b/Tests/MetaRouterTests/InitOptionsTests.swift
@@ -27,6 +27,85 @@ final class InitOptionsTests: XCTestCase {
         XCTAssertEqual(options.ingestionHost.path, "/base")
         XCTAssertEqual(options.ingestionHost.absoluteString, "https://host.tld/base")
     }
+
+    // MARK: - maxDiskEvents vs maxQueueEvents inversion warning
+
+    func testInversionWarningEmittedWhenDiskSmallerThanMemory() {
+        let output = captureStderrAndStdout {
+            _ = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                maxQueueEvents: 2000,
+                maxDiskEvents: 500
+            )
+        }
+        XCTAssertTrue(output.contains("maxDiskEvents"), "warning should mention maxDiskEvents, got: \(output)")
+        XCTAssertTrue(output.contains("maxQueueEvents"), "warning should mention maxQueueEvents")
+        XCTAssertTrue(output.contains("500") && output.contains("2000"), "warning should include both values")
+    }
+
+    func testNoInversionWarningWhenDiskLargerThanMemory() {
+        let output = captureStderrAndStdout {
+            _ = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                maxQueueEvents: 2000,
+                maxDiskEvents: 10_000
+            )
+        }
+        XCTAssertFalse(output.contains("maxDiskEvents") && output.contains("less than"),
+                       "no inversion warning should fire when disk >= memory")
+    }
+
+    func testNoInversionWarningWhenDiskDisabled() {
+        let output = captureStderrAndStdout {
+            _ = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                maxQueueEvents: 2000,
+                maxDiskEvents: 0
+            )
+        }
+        XCTAssertFalse(output.contains("less than"),
+                       "disk=0 is the 'disable persistence' case, not an inversion")
+    }
+
+    func testNoInversionWarningWhenEqual() {
+        let output = captureStderrAndStdout {
+            _ = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                maxQueueEvents: 2000,
+                maxDiskEvents: 2000
+            )
+        }
+        XCTAssertFalse(output.contains("less than"),
+                       "equal values are not an inversion")
+    }
+}
+
+/// Captures both stdout and stderr during `block`. Used to assert on Logger.warn output.
+/// Order matters: restore the original fds before reading so the pipe writer reaches EOF.
+private func captureStderrAndStdout(_ block: () -> Void) -> String {
+    let pipe = Pipe()
+    let origOut = dup(fileno(stdout))
+    let origErr = dup(fileno(stderr))
+    setvbuf(stdout, nil, _IONBF, 0)
+    setvbuf(stderr, nil, _IONBF, 0)
+    dup2(pipe.fileHandleForWriting.fileDescriptor, fileno(stdout))
+    dup2(pipe.fileHandleForWriting.fileDescriptor, fileno(stderr))
+
+    block()
+
+    // Restore stdout/stderr FIRST so no more writers reference the pipe
+    dup2(origOut, fileno(stdout))
+    dup2(origErr, fileno(stderr))
+    close(origOut)
+    close(origErr)
+    // Now safe to close the writer and read until EOF
+    pipe.fileHandleForWriting.closeFile()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
 }
 
 

--- a/Tests/MetaRouterTests/InitOptionsTests.swift
+++ b/Tests/MetaRouterTests/InitOptionsTests.swift
@@ -28,8 +28,6 @@ final class InitOptionsTests: XCTestCase {
         XCTAssertEqual(options.ingestionHost.absoluteString, "https://host.tld/base")
     }
 
-    // MARK: - maxDiskEvents vs maxQueueEvents inversion warning
-
     func testInversionWarningEmittedWhenDiskSmallerThanMemory() {
         let output = captureStderrAndStdout {
             _ = InitOptions(

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -345,6 +345,40 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertFalse(has)
     }
 
+    func testRequeueToFrontDropsNewestWhenMaxDiskEventsZero() async throws {
+        let queue = makeQueue(maxEventCount: 3, maxDiskEvents: 0)
+
+        // Fill memory: e1, e2, e3
+        await queue.enqueue(makeTestEvent(messageId: "e1"))
+        await queue.enqueue(makeTestEvent(messageId: "e2"))
+        await queue.enqueue(makeTestEvent(messageId: "e3"))
+
+        // Simulate a retry: drain (sends a batch), it fails, requeue to front
+        let batch = await queue.drain(max: 2)
+        XCTAssertEqual(batch.map(\.messageId), ["e1", "e2"])
+
+        // Memory now: [e3]. Requeue [e1, e2] to front.
+        await queue.requeueToFront([makeTestEvent(messageId: "e1"), makeTestEvent(messageId: "e2")])
+
+        // Memory should be [e1, e2, e3] — fits, no eviction
+        var contents = await queue.drain(max: 10)
+        XCTAssertEqual(contents.map(\.messageId), ["e1", "e2", "e3"])
+
+        // Now harder case: cap=2, fill with [a, b], requeue [r1, r2] — r1/r2 must survive,
+        // newest (b) must be dropped, NOT oldest (a) → drop-from-back semantics
+        let q2 = makeQueue(maxEventCount: 2, maxDiskEvents: 0)
+        await q2.enqueue(makeTestEvent(messageId: "a"))
+        await q2.enqueue(makeTestEvent(messageId: "b"))
+        await q2.requeueToFront([makeTestEvent(messageId: "r1"), makeTestEvent(messageId: "r2")])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path),
+                       "no disk file should be written in 0-mode")
+
+        contents = await q2.drain(max: 10)
+        XCTAssertEqual(contents.map(\.messageId), ["r1", "r2"],
+                       "requeued events must survive; newest entries (a, b) get dropped from the back")
+    }
+
     // MARK: - Cross-session persistence
 
     func testPersistsAcrossInstances() async throws {

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -435,6 +435,319 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertEqual(drained[0].messageId, "batch2-e0")
         XCTAssertEqual(drained[1].messageId, "batch2-e1")
     }
+
+    // MARK: - Offline Overflow Tests
+
+    func testOverflowBuffersToDiskinsteadOfDropping() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Fill to capacity
+        await queue.enqueue(makeTestEvent(messageId: "e1"))
+        await queue.enqueue(makeTestEvent(messageId: "e2"))
+        await queue.enqueue(makeTestEvent(messageId: "e3"))
+
+        // This enqueue should evict e1 to overflow buffer, not drop it
+        await queue.enqueue(makeTestEvent(messageId: "e4"))
+        await queue.enqueue(makeTestEvent(messageId: "e5"))
+
+        // Memory queue should have newest 3
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 3)
+        let drained = await queue.drain(max: 10)
+        XCTAssertEqual(drained.map(\.messageId), ["e3", "e4", "e5"])
+
+        // Overflow buffer should have evicted events (flush to check)
+        await queue.flushOverflowBufferToDisk()
+        let overflowBatch = await queue.readOverflowBatch(max: 10)
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e1", "e2"])
+    }
+
+    func testOverflowDisabledDropsAsUsual() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowDisabledTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        // Overflow NOT enabled — events should be dropped as usual
+        await queue.enqueue(makeTestEvent(messageId: "e1"))
+        await queue.enqueue(makeTestEvent(messageId: "e2"))
+        await queue.enqueue(makeTestEvent(messageId: "e3"))
+        await queue.enqueue(makeTestEvent(messageId: "e4"))
+
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 3)
+
+        let overflowCount = await queue.overflowCount()
+        XCTAssertEqual(overflowCount, 0, "No overflow events should exist when overflow is disabled")
+    }
+
+    func testOverflowDiskCapDropsOldest() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowCapTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 5
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Fill memory, then overflow 8 events (exceeds cap of 5)
+        for i in 0..<11 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // Memory has 3 newest: e8, e9, e10
+        let memDrained = await queue.drain(max: 10)
+        XCTAssertEqual(memDrained.map(\.messageId), ["e8", "e9", "e10"])
+
+        // Overflow disk should have exactly 5 (cap), with oldest dropped
+        await queue.flushOverflowBufferToDisk()
+        let overflowBatch = await queue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowBatch.count, 5)
+        // Should have e3..e7 (oldest e0..e2 dropped by disk cap)
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e3", "e4", "e5", "e6", "e7"])
+    }
+
+    func testOverflowBatchedWriteNotPerEvent() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowBatchTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Fill memory and overflow 50 events (below batch threshold of 100)
+        for i in 0..<53 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // The overflow file should NOT exist yet since buffer hasn't hit threshold
+        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
+        let fileExistsBeforeFlush = FileManager.default.fileExists(atPath: overflowPath.path)
+        XCTAssertFalse(fileExistsBeforeFlush,
+            "Buffer should batch writes, not write per event (50 events < 100 batch threshold)")
+
+        // Explicitly flush buffer to disk
+        await queue.flushOverflowBufferToDisk()
+        let overflowBatch = await queue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowBatch.count, 50, "All 50 overflow events should be on disk after flush")
+    }
+
+    func testOverflowAutoFlushesAtBatchThreshold() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowAutoFlush-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Overflow 103 events (100 = batch threshold, should auto-flush first 100)
+        for i in 0..<106 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // After 103 overflows, the first 100 should have auto-flushed to disk
+        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path),
+            "Overflow should auto-flush to disk at batch threshold")
+
+        // Flush remaining buffer and verify total
+        await queue.flushOverflowBufferToDisk()
+        let total = await queue.readOverflowBatch(max: 10000)
+        XCTAssertEqual(total.count, 103, "All overflow events should be persisted after flush")
+    }
+
+    func testDrainReadsThenRemovesBatches() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DrainTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
+        // Seed overflow disk with events
+        let events = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
+        try await overflowDisk.write(QueueSnapshot(events: events))
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+
+        // Read batch
+        let batch = await queue.readOverflowBatch(max: 3)
+        XCTAssertEqual(batch.count, 3)
+        XCTAssertEqual(batch.map(\.messageId), ["overflow-0", "overflow-1", "overflow-2"])
+
+        // Remove batch
+        await queue.removeOverflowBatch(count: 3)
+
+        // Remaining should be 2
+        let remaining = await queue.readOverflowBatch(max: 10)
+        XCTAssertEqual(remaining.count, 2)
+        XCTAssertEqual(remaining.map(\.messageId), ["overflow-3", "overflow-4"])
+
+        // Remove last batch
+        await queue.removeOverflowBatch(count: 2)
+
+        // File should be deleted
+        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: overflowPath.path),
+            "Overflow file should be deleted when all events are drained")
+    }
+
+    func testClearDeletesOverflowDisk() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClearOverflowTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Fill and overflow
+        for i in 0..<6 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+        await queue.flushOverflowBufferToDisk()
+
+        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path))
+
+        await queue.clear()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: overflowPath.path),
+            "clear() must delete overflow disk file")
+        let count = await queue.count
+        XCTAssertEqual(count, 0)
+    }
+
+    func testFlushToDiskAlsoFlushesOverflowBuffer() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FlushBothTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Fill and overflow (but below batch threshold, so buffer not yet written)
+        for i in 0..<6 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // flushToDisk should persist both memory queue and overflow buffer
+        try await queue.flushToDisk()
+
+        // Verify overflow was persisted
+        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
+        let snapshot = await overflowDisk.read()
+        XCTAssertEqual(snapshot?.events.count, 3, "Overflow buffer should be flushed by flushToDisk")
+    }
+
+    func testAppKillWhileOfflineThenRelaunchOnline() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RelaunchTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        // Phase 1: Simulate offline session — fill memory, overflow to disk
+        let queue1 = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        await queue1.setOfflineOverflowEnabled(true)
+        for i in 0..<8 {
+            await queue1.enqueue(makeTestEvent(messageId: "session1-\(i)"))
+        }
+        // Simulate app backgrounding / kill
+        try await queue1.flushToDisk()
+
+        // Phase 2: Simulate relaunch — new queue instance reads from disk
+        let queue2 = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 1000
+        )
+
+        // Rehydrate memory queue
+        let rehydrated = await queue2.rehydrate()
+        XCTAssertEqual(rehydrated, 3, "Memory queue should rehydrate from main disk")
+
+        // Overflow should still be on disk from previous session
+        let overflowBatch = await queue2.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowBatch.count, 5, "Overflow events should persist across app restart")
+        XCTAssertEqual(overflowBatch.first?.messageId, "session1-0")
+    }
+
+    func testOverflowNoOpWhenStorageNil() async throws {
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: nil,
+            maxOfflineDiskEvents: 1000
+        )
+
+        // setOfflineOverflowEnabled is a no-op when storage is nil
+        await queue.setOfflineOverflowEnabled(true)
+
+        // Events beyond capacity should just be dropped (existing behavior)
+        for i in 0..<5 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        let count = await queue.count
+        XCTAssertEqual(count, 3)
+
+        let overflowCount = await queue.overflowCount()
+        XCTAssertEqual(overflowCount, 0, "No overflow should exist without overflow storage")
+    }
 }
 
 

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -26,8 +26,6 @@ final class PersistentEventQueueTests: XCTestCase {
         tempDir.appendingPathComponent("queue.v1.json")
     }
 
-    // MARK: - Memory queue basics
-
     func testEnqueueWritesToMemoryOnly() async throws {
         let queue = makeQueue()
         await queue.enqueue(makeTestEvent(messageId: "e1"))
@@ -48,8 +46,6 @@ final class PersistentEventQueueTests: XCTestCase {
         let remaining = await queue.count
         XCTAssertEqual(remaining, 1)
     }
-
-    // MARK: - flushMemoryToDisk
 
     func testFlushMemoryToDiskWritesAndClearsMemory() async throws {
         let queue = makeQueue()
@@ -105,7 +101,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertNil(snapshot)
     }
 
-    // MARK: - Capacity overflow flushes to disk (no drops)
 
     func testEnqueueAtCapacityFlushesEntireMemoryToDisk() async throws {
         let queue = makeQueue(maxEventCount: 3)
@@ -141,7 +136,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertEqual(snapshot?.events.map(\.messageId), ["e1", "e2", "e3", "e4", "e5", "e6"])
     }
 
-    // MARK: - requeueToFront at capacity (bug fix)
 
     func testRequeueToFrontPreservesOrderBelowCapacity() async throws {
         let queue = makeQueue()
@@ -180,8 +174,6 @@ final class PersistentEventQueueTests: XCTestCase {
             "Displaced memory events must land on disk, not be dropped")
     }
 
-    // MARK: - checkForPersistedEvents
-
     func testCheckForPersistedEventsReturnsFalseWhenNoFile() async throws {
         let queue = makeQueue()
         let has = await queue.checkForPersistedEvents()
@@ -214,7 +206,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertEqual(memCount, 0, "Memory queue must start empty — events stay on disk")
     }
 
-    // MARK: - Drain primitives
 
     func testReadAllFromDiskAndDeleteClearsFile() async throws {
         let disk = DiskStorage(baseDirectory: tempDir)
@@ -264,7 +255,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
     }
 
-    // MARK: - Clear
 
     func testClearEmptiesMemoryAndDisk() async throws {
         let queue = makeQueue()
@@ -281,7 +271,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertFalse(hasDisk)
     }
 
-    // MARK: - Flush threshold
 
     func testFlushThresholdReachedByCount() async throws {
         let queue = PersistentEventQueue(
@@ -303,7 +292,6 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertTrue(needsFlush)
     }
 
-    // MARK: - Disk persistence disabled (maxDiskEvents = 0)
 
     func testFlushMemoryToDiskIsNoOpWhenMaxDiskEventsZero() async throws {
         let queue = makeQueue(maxDiskEvents: 0)
@@ -379,7 +367,6 @@ final class PersistentEventQueueTests: XCTestCase {
                        "requeued events must survive; newest entries (a, b) get dropped from the back")
     }
 
-    // MARK: - Cross-session persistence
 
     func testPersistsAcrossInstances() async throws {
         let queue1 = makeQueue()
@@ -399,6 +386,50 @@ final class PersistentEventQueueTests: XCTestCase {
 
         let drained = await queue2.readAllFromDiskAndDelete()
         XCTAssertEqual(drained.map(\.messageId), ["s1-0", "s1-1", "s1-2", "s1-3", "s1-4"])
+    }
+
+    func testReadAllFromDiskAndDeleteFiltersEventsOlderThanTTL() async throws {
+        let iso = ISO8601DateFormatter()
+        let recent = iso.string(from: Date())
+        let expired = iso.string(from: Date().addingTimeInterval(-8 * 24 * 60 * 60)) // 8 days ago
+
+        let disk = DiskStorage(baseDirectory: tempDir)
+        let events = [
+            makeTestEvent(messageId: "expired-1", timestamp: expired),
+            makeTestEvent(messageId: "recent-1", timestamp: recent),
+            makeTestEvent(messageId: "expired-2", timestamp: expired),
+            makeTestEvent(messageId: "recent-2", timestamp: recent),
+        ]
+        try await disk.write(QueueSnapshot(events: events))
+
+        let queue = makeQueue()
+        _ = await queue.checkForPersistedEvents()
+        let drained = await queue.readAllFromDiskAndDelete()
+
+        XCTAssertEqual(drained.map(\.messageId), ["recent-1", "recent-2"],
+                       "Events older than 7 days should be filtered out on drain")
+    }
+
+    // MARK: - Byte cap enforcement on enqueue
+
+    func testEnqueueAtByteCapFlushesMemoryToDisk() async throws {
+        // maxSizeBytes small enough that a few test events exceed it.
+        let queue = PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 1000,   // count cap won't trip
+            maxSizeBytes: 1500,
+            maxDiskEvents: 10_000
+        )
+
+        for i in 1...8 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        let memCount = await queue.count
+        XCTAssertLessThan(memCount, 8, "Byte cap should have triggered a flush; memory should not hold all 8")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: diskFilePath.path),
+                      "Byte cap flush should have written to disk")
     }
 }
 

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -13,206 +13,284 @@ final class PersistentEventQueueTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
-
-    func testEnqueueWritesToMemoryOnly() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
+    private func makeQueue(maxEventCount: Int = 2000, maxDiskEvents: Int = 10_000) -> PersistentEventQueue {
+        PersistentEventQueue(
+            diskStore: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: maxEventCount,
+            maxSizeBytes: 5_000_000,
+            maxDiskEvents: maxDiskEvents
         )
-
-        await queue.enqueue(makeTestEvent(messageId: "e1"))
-        let count = await queue.count
-        XCTAssertEqual(count, 1)
-
-        XCTAssertFalse(FileManager.default.fileExists(
-            atPath: tempDir.appendingPathComponent("queue.v1.json").path
-        ))
     }
 
+    private var diskFilePath: URL {
+        tempDir.appendingPathComponent("queue.v1.json")
+    }
+
+    // MARK: - Memory queue basics
+
+    func testEnqueueWritesToMemoryOnly() async throws {
+        let queue = makeQueue()
+        await queue.enqueue(makeTestEvent(messageId: "e1"))
+
+        let count = await queue.count
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
+    }
 
     func testDrainReadsFromMemoryOnly() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
+        let queue = makeQueue()
         await queue.enqueue(makeTestEvent(messageId: "e1"))
         await queue.enqueue(makeTestEvent(messageId: "e2"))
 
         let drained = await queue.drain(max: 1)
-        XCTAssertEqual(drained.count, 1)
-        XCTAssertEqual(drained[0].messageId, "e1")
+        XCTAssertEqual(drained.map(\.messageId), ["e1"])
 
         let remaining = await queue.count
         XCTAssertEqual(remaining, 1)
     }
 
+    // MARK: - flushMemoryToDisk
 
-    func testFlushToDiskWritesCurrentMemoryState() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
+    func testFlushMemoryToDiskWritesAndClearsMemory() async throws {
+        let queue = makeQueue()
         await queue.enqueue(makeTestEvent(messageId: "e1"))
         await queue.enqueue(makeTestEvent(messageId: "e2"))
 
-        try await queue.flushToDisk()
+        let flushed = await queue.flushMemoryToDisk()
+        XCTAssertTrue(flushed)
 
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = await diskStorage.read()
-        XCTAssertEqual(snapshot?.events.count, 2)
-        XCTAssertEqual(snapshot?.events[0].messageId, "e1")
+        let count = await queue.count
+        XCTAssertEqual(count, 0, "Memory should be empty after flush")
+
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["e1", "e2"])
     }
 
-    func testFlushToDiskOverwritesPreviousState() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
+    func testFlushMemoryToDiskAppendsToExistingDiskContents() async throws {
+        let queue = makeQueue()
 
+        // First flush
         await queue.enqueue(makeTestEvent(messageId: "e1"))
-        try await queue.flushToDisk()
+        _ = await queue.flushMemoryToDisk()
 
-        _ = await queue.drain(max: 1)
+        // Second flush — should append, not overwrite
         await queue.enqueue(makeTestEvent(messageId: "e2"))
-        try await queue.flushToDisk()
+        _ = await queue.flushMemoryToDisk()
 
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = await diskStorage.read()
-        XCTAssertEqual(snapshot?.events.count, 1)
-        XCTAssertEqual(snapshot?.events[0].messageId, "e2")
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["e1", "e2"],
+            "Second flush should append to existing disk contents")
     }
 
-    func testFlushToDiskWithEmptyQueueSkipsWrite() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
+    func testFlushMemoryToDiskEnforcesMaxDiskEvents() async throws {
+        let queue = makeQueue(maxEventCount: 100, maxDiskEvents: 5)
 
-        try await queue.flushToDisk()
+        for i in 0..<12 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+        _ = await queue.flushMemoryToDisk()
 
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = await diskStorage.read()
-        XCTAssertNil(snapshot, "Empty queue should not write a snapshot to disk")
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.count, 5, "Disk cap should drop oldest")
+        XCTAssertEqual(snapshot?.events.first?.messageId, "e7")
+        XCTAssertEqual(snapshot?.events.last?.messageId, "e11")
     }
 
+    func testFlushMemoryToDiskWithEmptyQueueIsNoOp() async throws {
+        let queue = makeQueue()
+        let flushed = await queue.flushMemoryToDisk()
+        XCTAssertFalse(flushed)
 
-    func testRehydrateLoadsEventsFromDisk() async throws {
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = QueueSnapshot(events: [
-            makeTestEvent(messageId: "disk1"),
-            makeTestEvent(messageId: "disk2"),
-        ])
-        try await diskStorage.write(snapshot)
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
-        let rehydratedCount = await queue.rehydrate()
-
-        XCTAssertEqual(rehydratedCount, 2)
-        let count = await queue.count
-        XCTAssertEqual(count, 2)
-
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "disk1")
-        XCTAssertEqual(drained[1].messageId, "disk2")
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertNil(snapshot)
     }
 
-    func testRehydrateIsIdempotentViaDiskDeletion() async throws {
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = QueueSnapshot(events: [makeTestEvent(messageId: "disk1")])
-        try await diskStorage.write(snapshot)
+    // MARK: - Capacity overflow flushes to disk (no drops)
 
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let count1 = await queue.rehydrate()
-        XCTAssertEqual(count1, 1)
-
-        // Second rehydrate is a no-op because disk file was deleted
-        let count2 = await queue.rehydrate()
-        XCTAssertEqual(count2, 0)
-    }
-
-    func testRehydrateEnforcesCapacity() async throws {
-        let events = (0..<10).map { makeTestEvent(messageId: "e\($0)") }
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        try await diskStorage.write(QueueSnapshot(events: events))
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 5,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue.rehydrate()
-
-        XCTAssertEqual(rehydrated, 5)
-        let count = await queue.count
-        XCTAssertEqual(count, 5)
-
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "e5")
-        XCTAssertEqual(drained[4].messageId, "e9")
-    }
-
-    func testRehydrateDeletesDiskFileAfterLoading() async throws {
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        try await diskStorage.write(QueueSnapshot(events: [makeTestEvent()]))
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        _ = await queue.rehydrate()
-
-        let fileExists = FileManager.default.fileExists(
-            atPath: tempDir.appendingPathComponent("queue.v1.json").path
-        )
-        XCTAssertFalse(fileExists, "Disk file should be deleted after rehydration")
-    }
-
-
-    func testCapacityEnforcementDropsOldest() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            maxSizeBytes: 5_000_000
-        )
+    func testEnqueueAtCapacityFlushesEntireMemoryToDisk() async throws {
+        let queue = makeQueue(maxEventCount: 3)
 
         await queue.enqueue(makeTestEvent(messageId: "e1"))
         await queue.enqueue(makeTestEvent(messageId: "e2"))
         await queue.enqueue(makeTestEvent(messageId: "e3"))
+
+        // e4 triggers a flush of e1-e3 to disk before inserting
         await queue.enqueue(makeTestEvent(messageId: "e4"))
 
-        let count = await queue.count
-        XCTAssertEqual(count, 3)
-
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 1, "Memory should only have e4 after capacity flush")
         let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "e2")
-        XCTAssertEqual(drained[2].messageId, "e4")
+        XCTAssertEqual(drained.map(\.messageId), ["e4"])
+
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["e1", "e2", "e3"])
     }
 
+    func testMultipleCapacityOverflowsAccumulateOnDisk() async throws {
+        let queue = makeQueue(maxEventCount: 3)
+
+        // 7 events with memory cap 3: flushes at e4 (wrote e1-e3) and at e7 (wrote e4-e6)
+        for i in 1...7 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 1)
+
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["e1", "e2", "e3", "e4", "e5", "e6"])
+    }
+
+    // MARK: - requeueToFront at capacity (bug fix)
+
+    func testRequeueToFrontPreservesOrderBelowCapacity() async throws {
+        let queue = makeQueue()
+        await queue.enqueue(makeTestEvent(messageId: "e3"))
+        await queue.requeueToFront([
+            makeTestEvent(messageId: "e1"),
+            makeTestEvent(messageId: "e2"),
+        ])
+
+        let drained = await queue.drain(max: 10)
+        XCTAssertEqual(drained.map(\.messageId), ["e1", "e2", "e3"])
+    }
+
+    func testRequeueToFrontAtCapacityFlushesMemoryToDisk() async throws {
+        let queue = makeQueue(maxEventCount: 3)
+
+        // Fill memory to capacity
+        await queue.enqueue(makeTestEvent(messageId: "m1"))
+        await queue.enqueue(makeTestEvent(messageId: "m2"))
+        await queue.enqueue(makeTestEvent(messageId: "m3"))
+
+        // Requeue 2 more — combined 5 > cap 3, so memory flushes first
+        await queue.requeueToFront([
+            makeTestEvent(messageId: "r1"),
+            makeTestEvent(messageId: "r2"),
+        ])
+
+        // Memory should have the requeued events only
+        let drained = await queue.drain(max: 10)
+        XCTAssertEqual(drained.map(\.messageId), ["r1", "r2"],
+            "Requeued events stay in memory")
+
+        // m1-m3 should be on disk (no drops)
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["m1", "m2", "m3"],
+            "Displaced memory events must land on disk, not be dropped")
+    }
+
+    // MARK: - checkForPersistedEvents
+
+    func testCheckForPersistedEventsReturnsFalseWhenNoFile() async throws {
+        let queue = makeQueue()
+        let has = await queue.checkForPersistedEvents()
+        XCTAssertFalse(has)
+        let hasDisk = await queue.hasDiskData
+        XCTAssertFalse(hasDisk)
+    }
+
+    func testCheckForPersistedEventsReturnsTrueWhenFileExists() async throws {
+        // Seed the disk
+        let disk = DiskStorage(baseDirectory: tempDir)
+        try await disk.write(QueueSnapshot(events: [makeTestEvent(messageId: "seeded")]))
+
+        let queue = makeQueue()
+        let has = await queue.checkForPersistedEvents()
+        XCTAssertTrue(has)
+        let hasDisk = await queue.hasDiskData
+        XCTAssertTrue(hasDisk)
+    }
+
+    func testCheckForPersistedEventsDoesNotLoadIntoMemory() async throws {
+        let disk = DiskStorage(baseDirectory: tempDir)
+        let events = (0..<5).map { makeTestEvent(messageId: "disk-\($0)") }
+        try await disk.write(QueueSnapshot(events: events))
+
+        let queue = makeQueue()
+        _ = await queue.checkForPersistedEvents()
+
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 0, "Memory queue must start empty — events stay on disk")
+    }
+
+    // MARK: - Drain primitives
+
+    func testReadAllFromDiskAndDeleteClearsFile() async throws {
+        let disk = DiskStorage(baseDirectory: tempDir)
+        let events = (0..<5).map { makeTestEvent(messageId: "d\($0)") }
+        try await disk.write(QueueSnapshot(events: events))
+
+        let queue = makeQueue()
+        _ = await queue.checkForPersistedEvents()
+
+        let loaded = await queue.readAllFromDiskAndDelete()
+        XCTAssertEqual(loaded.map(\.messageId), ["d0", "d1", "d2", "d3", "d4"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
+        let hasDisk = await queue.hasDiskData
+        XCTAssertFalse(hasDisk)
+    }
+
+    func testWriteDiskStoreOverwrites() async throws {
+        let queue = makeQueue()
+        await queue.writeDiskStore([makeTestEvent(messageId: "v1")])
+        await queue.writeDiskStore([makeTestEvent(messageId: "v2-a"), makeTestEvent(messageId: "v2-b")])
+
+        let snapshot = await DiskStorage(baseDirectory: tempDir).read()
+        XCTAssertEqual(snapshot?.events.map(\.messageId), ["v2-a", "v2-b"])
+        let hasDisk = await queue.hasDiskData
+        XCTAssertTrue(hasDisk)
+    }
+
+    func testWriteDiskStoreWithEmptyDeletesFile() async throws {
+        let queue = makeQueue()
+        await queue.writeDiskStore([makeTestEvent(messageId: "v1")])
+        await queue.writeDiskStore([])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
+        let hasDisk = await queue.hasDiskData
+        XCTAssertFalse(hasDisk)
+    }
+
+    func testDeleteDiskStoreClearsFlag() async throws {
+        let queue = makeQueue()
+        await queue.writeDiskStore([makeTestEvent(messageId: "e1")])
+        let hasDisk = await queue.hasDiskData
+        XCTAssertTrue(hasDisk)
+
+        await queue.deleteDiskStore()
+        let hasDiskAfter = await queue.hasDiskData
+        XCTAssertFalse(hasDiskAfter)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
+    }
+
+    // MARK: - Clear
+
+    func testClearEmptiesMemoryAndDisk() async throws {
+        let queue = makeQueue()
+        await queue.enqueue(makeTestEvent(messageId: "m1"))
+        _ = await queue.flushMemoryToDisk()
+        await queue.enqueue(makeTestEvent(messageId: "m2"))
+
+        await queue.clear()
+
+        let count = await queue.count
+        XCTAssertEqual(count, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path))
+        let hasDisk = await queue.hasDiskData
+        XCTAssertFalse(hasDisk)
+    }
+
+    // MARK: - Flush threshold
 
     func testFlushThresholdReachedByCount() async throws {
         let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
+            diskStore: DiskStorage(baseDirectory: tempDir),
             maxEventCount: 2000,
             maxSizeBytes: 5_000_000,
             flushThresholdCount: 3,
-            flushThresholdBytes: 5_000_000
+            flushThresholdBytes: 5_000_000,
+            maxDiskEvents: 10_000
         )
 
         await queue.enqueue(makeTestEvent(messageId: "e1"))
@@ -225,520 +303,26 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertTrue(needsFlush)
     }
 
+    // MARK: - Cross-session persistence
 
-    func testRequeueToFront() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
-        await queue.enqueue(makeTestEvent(messageId: "e3"))
-        await queue.requeueToFront([
-            makeTestEvent(messageId: "e1"),
-            makeTestEvent(messageId: "e2"),
-        ])
-
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained.map(\.messageId), ["e1", "e2", "e3"])
-    }
-
-
-    func testRehydrateDropsEventsOlderThan7Days() async throws {
-        let now = Date()
-        let eightDaysAgo = now.addingTimeInterval(-8 * 24 * 60 * 60)
-        let sixDaysAgo = now.addingTimeInterval(-6 * 24 * 60 * 60)
-
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = QueueSnapshot(events: [
-            makeTestEvent(messageId: "old", timestamp: iso8601(eightDaysAgo)),
-            makeTestEvent(messageId: "recent", timestamp: iso8601(sixDaysAgo)),
-            makeTestEvent(messageId: "fresh", timestamp: iso8601(now)),
-        ])
-        try await diskStorage.write(snapshot)
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue.rehydrate()
-
-        XCTAssertEqual(rehydrated, 2)
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained.map(\.messageId), ["recent", "fresh"])
-    }
-
-    func testRehydrateKeepsEventsWithUnparseableTimestamp() async throws {
-        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
-
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = QueueSnapshot(events: [
-            makeTestEvent(messageId: "unparseable", timestamp: "not-a-date"),
-            makeTestEvent(messageId: "old", timestamp: iso8601(eightDaysAgo)),
-        ])
-        try await diskStorage.write(snapshot)
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue.rehydrate()
-
-        // Unparseable kept (fail-open), old one dropped
-        XCTAssertEqual(rehydrated, 1)
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "unparseable")
-    }
-
-    func testRehydrateDropsAllExpiredEvents() async throws {
-        let eightDaysAgo = Date().addingTimeInterval(-8 * 24 * 60 * 60)
-        let tenDaysAgo = Date().addingTimeInterval(-10 * 24 * 60 * 60)
-
-        let diskStorage = DiskStorage(baseDirectory: tempDir)
-        let snapshot = QueueSnapshot(events: [
-            makeTestEvent(messageId: "e1", timestamp: iso8601(eightDaysAgo)),
-            makeTestEvent(messageId: "e2", timestamp: iso8601(tenDaysAgo)),
-        ])
-        try await diskStorage.write(snapshot)
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue.rehydrate()
-
-        XCTAssertEqual(rehydrated, 0)
-        let count = await queue.count
-        XCTAssertEqual(count, 0)
-    }
-
-
-    func testClear() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
-        await queue.enqueue(makeTestEvent(messageId: "e1"))
-        try await queue.flushToDisk()
-
-        XCTAssertTrue(FileManager.default.fileExists(
-            atPath: tempDir.appendingPathComponent("queue.v1.json").path
-        ))
-
-        await queue.clear()
-
-        let count = await queue.count
-        XCTAssertEqual(count, 0)
-
-        XCTAssertFalse(FileManager.default.fileExists(
-            atPath: tempDir.appendingPathComponent("queue.v1.json").path
-        ), "clear() must delete disk snapshot to prevent stale rehydration")
-    }
-
-
-    func testFullRoundTrip_EnqueueFlushRehydrate() async throws {
-        // Phase 1: Enqueue events and flush to disk
-        let queue1 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
+    func testPersistsAcrossInstances() async throws {
+        let queue1 = makeQueue()
         for i in 0..<5 {
-            await queue1.enqueue(makeTestEvent(messageId: "e\(i)"))
+            await queue1.enqueue(makeTestEvent(messageId: "s1-\(i)"))
         }
-        try await queue1.flushToDisk()
-
-        // Simulate new process
-
-
-        // Phase 2: Create new queue and rehydrate
-        let queue2 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue2.rehydrate()
-        XCTAssertEqual(rehydrated, 5)
-
-        // Phase 3: Verify order preserved
-        let drained = await queue2.drain(max: 10)
-        XCTAssertEqual(drained.count, 5)
-        for i in 0..<5 {
-            XCTAssertEqual(drained[i].messageId, "e\(i)")
-        }
-    }
-
-    func testPartialDrainThenFlush() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
-        for i in 0..<5 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-        _ = await queue.drain(max: 2) // removes e0, e1
-        try await queue.flushToDisk()
-
-
-
-        let queue2 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue2.rehydrate()
-        XCTAssertEqual(rehydrated, 3)
-
-        let drained = await queue2.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "e2")
-        XCTAssertEqual(drained[2].messageId, "e4")
-    }
-
-    func testFlushOverwriteEliminatesDuplicates() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-
-        // First flush with 3 events
-        for i in 0..<3 {
-            await queue.enqueue(makeTestEvent(messageId: "batch1-e\(i)"))
-        }
-        try await queue.flushToDisk()
-
-        // Drain all, enqueue 2 new events, flush again
-        _ = await queue.drain(max: 10)
-        await queue.enqueue(makeTestEvent(messageId: "batch2-e0"))
-        await queue.enqueue(makeTestEvent(messageId: "batch2-e1"))
-        try await queue.flushToDisk()
-
-
-
-        let queue2 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 2000,
-            maxSizeBytes: 5_000_000
-        )
-        let rehydrated = await queue2.rehydrate()
-
-        // Should only have batch2 events — full overwrite, no duplicates
-        XCTAssertEqual(rehydrated, 2)
-        let drained = await queue2.drain(max: 10)
-        XCTAssertEqual(drained[0].messageId, "batch2-e0")
-        XCTAssertEqual(drained[1].messageId, "batch2-e1")
-    }
-
-    // MARK: - Offline Overflow Tests
-
-    func testOverflowFlushesEntireQueueToDisk() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        // Fill to capacity
-        await queue.enqueue(makeTestEvent(messageId: "e1"))
-        await queue.enqueue(makeTestEvent(messageId: "e2"))
-        await queue.enqueue(makeTestEvent(messageId: "e3"))
-
-        // This enqueue triggers full queue flush to disk, then e4 is the only event in memory
-        await queue.enqueue(makeTestEvent(messageId: "e4"))
-
-        // Memory queue should have just the new event
-        let memCount = await queue.count
-        XCTAssertEqual(memCount, 1)
-        let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained.map(\.messageId), ["e4"])
-
-        // Overflow disk should have the full flushed queue
-        let overflowBatch = await queue.readOverflowBatch(max: 10)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e1", "e2", "e3"])
-    }
-
-    func testOverflowAlwaysFlushesRegardlessOfOnlineState() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowAlwaysTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        // No setOfflineOverflowEnabled call needed — overflow is always active
-        // when overflowDiskStorage exists and queue hits capacity
-        await queue.enqueue(makeTestEvent(messageId: "e1"))
-        await queue.enqueue(makeTestEvent(messageId: "e2"))
-        await queue.enqueue(makeTestEvent(messageId: "e3"))
-        await queue.enqueue(makeTestEvent(messageId: "e4"))
-
-        let memCount = await queue.count
-        XCTAssertEqual(memCount, 1)
-
-        let overflowBatch = await queue.readOverflowBatch(max: 10)
-        XCTAssertEqual(overflowBatch.count, 3, "Overflow should always flush to disk when storage exists")
-    }
-
-    func testOverflowDiskCapDropsOldest() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowCapTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 5
-        )
-
-        // Fill memory, then trigger multiple flushes (exceeds cap of 5)
-        // Each time the queue hits 3, it flushes all 3 to disk
-        for i in 0..<11 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        // Memory has the events after the last flush
-        // With capacity 3: flushes at e3 (writes e0,e1,e2), at e6 (writes e3,e4,e5), at e9 (writes e6,e7,e8)
-        // Memory has: e9, e10
-        let memDrained = await queue.drain(max: 10)
-        XCTAssertEqual(memDrained.map(\.messageId), ["e9", "e10"])
-
-        // Overflow disk should have exactly 5 (cap), with oldest dropped
-        let overflowBatch = await queue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 5)
-        // Should have e4..e8 (oldest e0..e3 dropped by disk cap)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e4", "e5", "e6", "e7", "e8"])
-    }
-
-    func testOverflowWritesToDiskImmediately() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowImmediateTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
-        )
-
-        // Fill to capacity and trigger overflow
-        for i in 0..<4 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        // Overflow file should exist immediately (no buffering)
-        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path),
-            "Overflow should write to disk immediately on capacity hit, no buffering")
-
-        let overflowBatch = await queue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 3, "All 3 flushed events should be on disk")
-    }
-
-    func testMultipleOverflowFlushesAccumulate() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowAccumulateTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
-        )
-
-        // Trigger multiple overflows: 7 events with capacity 3
-        // Flush at e3 (writes e0,e1,e2), flush at e6 (writes e3,e4,e5)
-        for i in 0..<7 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        // Memory should have e6
-        let memCount = await queue.count
-        XCTAssertEqual(memCount, 1)
-
-        // Overflow disk should have accumulated events from both flushes
-        let overflowBatch = await queue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 6)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e0", "e1", "e2", "e3", "e4", "e5"])
-    }
-
-    func testDrainReadsThenRemovesBatches() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DrainTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
-        // Seed overflow disk with events
-        let events = (0..<5).map { makeTestEvent(messageId: "overflow-\($0)") }
-        try await overflowDisk.write(QueueSnapshot(events: events))
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 100,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
-        )
-
-        // Read batch
-        let batch = await queue.readOverflowBatch(max: 3)
-        XCTAssertEqual(batch.count, 3)
-        XCTAssertEqual(batch.map(\.messageId), ["overflow-0", "overflow-1", "overflow-2"])
-
-        // Remove batch
-        await queue.removeOverflowBatch(count: 3)
-
-        // Remaining should be 2
-        let remaining = await queue.readOverflowBatch(max: 10)
-        XCTAssertEqual(remaining.count, 2)
-        XCTAssertEqual(remaining.map(\.messageId), ["overflow-3", "overflow-4"])
-
-        // Remove last batch
-        await queue.removeOverflowBatch(count: 2)
-
-        // File should be deleted
-        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: overflowPath.path),
-            "Overflow file should be deleted when all events are drained")
-    }
-
-    func testClearDeletesOverflowDisk() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("ClearOverflowTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        // Fill and trigger overflow flush to disk
-        for i in 0..<6 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path))
-
-        await queue.clear()
-
-        XCTAssertFalse(FileManager.default.fileExists(atPath: overflowPath.path),
-            "clear() must delete overflow disk file")
-        let count = await queue.count
-        XCTAssertEqual(count, 0)
-    }
-
-    func testAppKillWhileOfflineThenRelaunchOnline() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("RelaunchTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        // Phase 1: Simulate offline session — fill memory, overflow to disk
-        let queue1 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        for i in 0..<8 {
-            await queue1.enqueue(makeTestEvent(messageId: "session1-\(i)"))
-        }
-        // Simulate app backgrounding / kill
-        try await queue1.flushToDisk()
-
-        // Phase 2: Simulate relaunch — new queue instance reads from disk
-        let queue2 = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 100,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        // Rehydrate memory queue — with capacity 3, after 8 events:
-        // flushes at e3 (writes e0,e1,e2), at e6 (writes e3,e4,e5)
-        // memory has e6, e7 at time of flushToDisk
-        let rehydrated = await queue2.rehydrate()
-        XCTAssertEqual(rehydrated, 2, "Memory queue should rehydrate from main disk")
-
-        // Overflow should still be on disk from previous session
-        let overflowBatch = await queue2.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 6, "Overflow events should persist across app restart")
-        XCTAssertEqual(overflowBatch.first?.messageId, "session1-0")
-    }
-
-    func testOverflowNoOpWhenStorageNil() async throws {
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: nil,
-            maxOfflineDiskEvents: 1000
-        )
-
-        // Events beyond capacity should just be dropped (existing behavior)
-        for i in 0..<5 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        let count = await queue.count
-        XCTAssertEqual(count, 3)
-
-        // No overflow disk → flushToOverflowDisk is a no-op
-        let flushed = await queue.flushToOverflowDisk()
-        XCTAssertFalse(flushed, "No overflow should exist without overflow storage")
-    }
-
-    func testFlushToOverflowDiskDrainsMemoryQueue() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("ExplicitFlushTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 100,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
-        )
-
-        // Enqueue events (below capacity, so no automatic flush)
-        for i in 0..<5 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        let memBefore = await queue.count
-        XCTAssertEqual(memBefore, 5)
-
-        // Explicitly flush to overflow disk (e.g., when dispatcher detects offline)
-        let flushed = await queue.flushToOverflowDisk()
-        XCTAssertTrue(flushed)
-
-        // Memory should be empty
-        let memAfter = await queue.count
-        XCTAssertEqual(memAfter, 0)
-
-        // Overflow disk should have all events
-        let overflowBatch = await queue.readOverflowBatch(max: 10)
-        XCTAssertEqual(overflowBatch.count, 5)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e0", "e1", "e2", "e3", "e4"])
+        _ = await queue1.flushMemoryToDisk()
+
+        // Simulate relaunch
+        let queue2 = makeQueue()
+        let has = await queue2.checkForPersistedEvents()
+        XCTAssertTrue(has)
+
+        // Events are not in memory — they're on disk for the drain to pick up
+        let memCount = await queue2.count
+        XCTAssertEqual(memCount, 0)
+
+        let drained = await queue2.readAllFromDiskAndDelete()
+        XCTAssertEqual(drained.map(\.messageId), ["s1-0", "s1-1", "s1-2", "s1-3", "s1-4"])
     }
 }
 
@@ -759,8 +343,4 @@ private func makeTestEvent(messageId: String = "mid", timestamp: String = "now")
         properties: nil, traits: nil, integrations: nil,
         timestamp: timestamp, writeKey: "wk", messageId: messageId, context: ctx
     )
-}
-
-private func iso8601(_ date: Date) -> String {
-    ISO8601DateFormatter().string(from: date)
 }

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -303,6 +303,48 @@ final class PersistentEventQueueTests: XCTestCase {
         XCTAssertTrue(needsFlush)
     }
 
+    // MARK: - Disk persistence disabled (maxDiskEvents = 0)
+
+    func testFlushMemoryToDiskIsNoOpWhenMaxDiskEventsZero() async throws {
+        let queue = makeQueue(maxDiskEvents: 0)
+        await queue.enqueue(makeTestEvent(messageId: "e1"))
+        await queue.enqueue(makeTestEvent(messageId: "e2"))
+
+        let flushed = await queue.flushMemoryToDisk()
+        XCTAssertFalse(flushed, "flush should report no-op when persistence is disabled")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path),
+                       "No disk file should be written when maxDiskEvents == 0")
+
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 2, "Events should remain in memory when persistence is disabled")
+    }
+
+    func testEnqueueAtCapacityDropsOldestWhenMaxDiskEventsZero() async throws {
+        let queue = makeQueue(maxEventCount: 3, maxDiskEvents: 0)
+
+        for i in 1...5 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path),
+                       "Nothing should ever hit disk when persistence is disabled")
+
+        let drained = await queue.drain(max: 10)
+        XCTAssertEqual(drained.map(\.messageId), ["e3", "e4", "e5"],
+                       "Memory queue should drop oldest (ring buffer) when persistence disabled")
+    }
+
+    func testWriteDiskStoreIsNoOpWhenMaxDiskEventsZero() async throws {
+        let queue = makeQueue(maxDiskEvents: 0)
+        await queue.writeDiskStore([makeTestEvent(messageId: "e1")])
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: diskFilePath.path),
+                       "writeDiskStore should no-op when persistence is disabled")
+        let has = await queue.hasDiskData
+        XCTAssertFalse(has)
+    }
+
     // MARK: - Cross-session persistence
 
     func testPersistsAcrossInstances() async throws {

--- a/Tests/MetaRouterTests/PersistentEventQueueTests.swift
+++ b/Tests/MetaRouterTests/PersistentEventQueueTests.swift
@@ -438,7 +438,7 @@ final class PersistentEventQueueTests: XCTestCase {
 
     // MARK: - Offline Overflow Tests
 
-    func testOverflowBuffersToDiskinsteadOfDropping() async throws {
+    func testOverflowFlushesEntireQueueToDisk() async throws {
         let overflowDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("OverflowTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: overflowDir) }
@@ -450,32 +450,28 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        await queue.setOfflineOverflowEnabled(true)
-
         // Fill to capacity
         await queue.enqueue(makeTestEvent(messageId: "e1"))
         await queue.enqueue(makeTestEvent(messageId: "e2"))
         await queue.enqueue(makeTestEvent(messageId: "e3"))
 
-        // This enqueue should evict e1 to overflow buffer, not drop it
+        // This enqueue triggers full queue flush to disk, then e4 is the only event in memory
         await queue.enqueue(makeTestEvent(messageId: "e4"))
-        await queue.enqueue(makeTestEvent(messageId: "e5"))
 
-        // Memory queue should have newest 3
+        // Memory queue should have just the new event
         let memCount = await queue.count
-        XCTAssertEqual(memCount, 3)
+        XCTAssertEqual(memCount, 1)
         let drained = await queue.drain(max: 10)
-        XCTAssertEqual(drained.map(\.messageId), ["e3", "e4", "e5"])
+        XCTAssertEqual(drained.map(\.messageId), ["e4"])
 
-        // Overflow buffer should have evicted events (flush to check)
-        await queue.flushOverflowBufferToDisk()
+        // Overflow disk should have the full flushed queue
         let overflowBatch = await queue.readOverflowBatch(max: 10)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e1", "e2"])
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e1", "e2", "e3"])
     }
 
-    func testOverflowDisabledDropsAsUsual() async throws {
+    func testOverflowAlwaysFlushesRegardlessOfOnlineState() async throws {
         let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowDisabledTest-\(UUID().uuidString)")
+            .appendingPathComponent("OverflowAlwaysTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: overflowDir) }
 
         let queue = PersistentEventQueue(
@@ -485,17 +481,18 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        // Overflow NOT enabled — events should be dropped as usual
+        // No setOfflineOverflowEnabled call needed — overflow is always active
+        // when overflowDiskStorage exists and queue hits capacity
         await queue.enqueue(makeTestEvent(messageId: "e1"))
         await queue.enqueue(makeTestEvent(messageId: "e2"))
         await queue.enqueue(makeTestEvent(messageId: "e3"))
         await queue.enqueue(makeTestEvent(messageId: "e4"))
 
         let memCount = await queue.count
-        XCTAssertEqual(memCount, 3)
+        XCTAssertEqual(memCount, 1)
 
-        let overflowCount = await queue.overflowCount()
-        XCTAssertEqual(overflowCount, 0, "No overflow events should exist when overflow is disabled")
+        let overflowBatch = await queue.readOverflowBatch(max: 10)
+        XCTAssertEqual(overflowBatch.count, 3, "Overflow should always flush to disk when storage exists")
     }
 
     func testOverflowDiskCapDropsOldest() async throws {
@@ -510,28 +507,28 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 5
         )
 
-        await queue.setOfflineOverflowEnabled(true)
-
-        // Fill memory, then overflow 8 events (exceeds cap of 5)
+        // Fill memory, then trigger multiple flushes (exceeds cap of 5)
+        // Each time the queue hits 3, it flushes all 3 to disk
         for i in 0..<11 {
             await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
         }
 
-        // Memory has 3 newest: e8, e9, e10
+        // Memory has the events after the last flush
+        // With capacity 3: flushes at e3 (writes e0,e1,e2), at e6 (writes e3,e4,e5), at e9 (writes e6,e7,e8)
+        // Memory has: e9, e10
         let memDrained = await queue.drain(max: 10)
-        XCTAssertEqual(memDrained.map(\.messageId), ["e8", "e9", "e10"])
+        XCTAssertEqual(memDrained.map(\.messageId), ["e9", "e10"])
 
         // Overflow disk should have exactly 5 (cap), with oldest dropped
-        await queue.flushOverflowBufferToDisk()
         let overflowBatch = await queue.readOverflowBatch(max: 100)
         XCTAssertEqual(overflowBatch.count, 5)
-        // Should have e3..e7 (oldest e0..e2 dropped by disk cap)
-        XCTAssertEqual(overflowBatch.map(\.messageId), ["e3", "e4", "e5", "e6", "e7"])
+        // Should have e4..e8 (oldest e0..e3 dropped by disk cap)
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e4", "e5", "e6", "e7", "e8"])
     }
 
-    func testOverflowBatchedWriteNotPerEvent() async throws {
+    func testOverflowWritesToDiskImmediately() async throws {
         let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowBatchTest-\(UUID().uuidString)")
+            .appendingPathComponent("OverflowImmediateTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: overflowDir) }
 
         let queue = PersistentEventQueue(
@@ -541,53 +538,46 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 10000
         )
 
-        await queue.setOfflineOverflowEnabled(true)
-
-        // Fill memory and overflow 50 events (below batch threshold of 100)
-        for i in 0..<53 {
+        // Fill to capacity and trigger overflow
+        for i in 0..<4 {
             await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
         }
 
-        // The overflow file should NOT exist yet since buffer hasn't hit threshold
-        let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
-        let fileExistsBeforeFlush = FileManager.default.fileExists(atPath: overflowPath.path)
-        XCTAssertFalse(fileExistsBeforeFlush,
-            "Buffer should batch writes, not write per event (50 events < 100 batch threshold)")
-
-        // Explicitly flush buffer to disk
-        await queue.flushOverflowBufferToDisk()
-        let overflowBatch = await queue.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 50, "All 50 overflow events should be on disk after flush")
-    }
-
-    func testOverflowAutoFlushesAtBatchThreshold() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("OverflowAutoFlush-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 10000
-        )
-
-        await queue.setOfflineOverflowEnabled(true)
-
-        // Overflow 103 events (100 = batch threshold, should auto-flush first 100)
-        for i in 0..<106 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        // After 103 overflows, the first 100 should have auto-flushed to disk
+        // Overflow file should exist immediately (no buffering)
         let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path),
-            "Overflow should auto-flush to disk at batch threshold")
+            "Overflow should write to disk immediately on capacity hit, no buffering")
 
-        // Flush remaining buffer and verify total
-        await queue.flushOverflowBufferToDisk()
-        let total = await queue.readOverflowBatch(max: 10000)
-        XCTAssertEqual(total.count, 103, "All overflow events should be persisted after flush")
+        let overflowBatch = await queue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowBatch.count, 3, "All 3 flushed events should be on disk")
+    }
+
+    func testMultipleOverflowFlushesAccumulate() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OverflowAccumulateTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 3,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+
+        // Trigger multiple overflows: 7 events with capacity 3
+        // Flush at e3 (writes e0,e1,e2), flush at e6 (writes e3,e4,e5)
+        for i in 0..<7 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        // Memory should have e6
+        let memCount = await queue.count
+        XCTAssertEqual(memCount, 1)
+
+        // Overflow disk should have accumulated events from both flushes
+        let overflowBatch = await queue.readOverflowBatch(max: 100)
+        XCTAssertEqual(overflowBatch.count, 6)
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e0", "e1", "e2", "e3", "e4", "e5"])
     }
 
     func testDrainReadsThenRemovesBatches() async throws {
@@ -641,13 +631,10 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        await queue.setOfflineOverflowEnabled(true)
-
-        // Fill and overflow
+        // Fill and trigger overflow flush to disk
         for i in 0..<6 {
             await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
         }
-        await queue.flushOverflowBufferToDisk()
 
         let overflowPath = overflowDir.appendingPathComponent("overflow.v1.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: overflowPath.path))
@@ -658,34 +645,6 @@ final class PersistentEventQueueTests: XCTestCase {
             "clear() must delete overflow disk file")
         let count = await queue.count
         XCTAssertEqual(count, 0)
-    }
-
-    func testFlushToDiskAlsoFlushesOverflowBuffer() async throws {
-        let overflowDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("FlushBothTest-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: overflowDir) }
-
-        let queue = PersistentEventQueue(
-            diskStorage: DiskStorage(baseDirectory: tempDir),
-            maxEventCount: 3,
-            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
-            maxOfflineDiskEvents: 1000
-        )
-
-        await queue.setOfflineOverflowEnabled(true)
-
-        // Fill and overflow (but below batch threshold, so buffer not yet written)
-        for i in 0..<6 {
-            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
-        }
-
-        // flushToDisk should persist both memory queue and overflow buffer
-        try await queue.flushToDisk()
-
-        // Verify overflow was persisted
-        let overflowDisk = DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json")
-        let snapshot = await overflowDisk.read()
-        XCTAssertEqual(snapshot?.events.count, 3, "Overflow buffer should be flushed by flushToDisk")
     }
 
     func testAppKillWhileOfflineThenRelaunchOnline() async throws {
@@ -701,7 +660,6 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        await queue1.setOfflineOverflowEnabled(true)
         for i in 0..<8 {
             await queue1.enqueue(makeTestEvent(messageId: "session1-\(i)"))
         }
@@ -716,13 +674,15 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        // Rehydrate memory queue
+        // Rehydrate memory queue — with capacity 3, after 8 events:
+        // flushes at e3 (writes e0,e1,e2), at e6 (writes e3,e4,e5)
+        // memory has e6, e7 at time of flushToDisk
         let rehydrated = await queue2.rehydrate()
-        XCTAssertEqual(rehydrated, 3, "Memory queue should rehydrate from main disk")
+        XCTAssertEqual(rehydrated, 2, "Memory queue should rehydrate from main disk")
 
         // Overflow should still be on disk from previous session
         let overflowBatch = await queue2.readOverflowBatch(max: 100)
-        XCTAssertEqual(overflowBatch.count, 5, "Overflow events should persist across app restart")
+        XCTAssertEqual(overflowBatch.count, 6, "Overflow events should persist across app restart")
         XCTAssertEqual(overflowBatch.first?.messageId, "session1-0")
     }
 
@@ -734,9 +694,6 @@ final class PersistentEventQueueTests: XCTestCase {
             maxOfflineDiskEvents: 1000
         )
 
-        // setOfflineOverflowEnabled is a no-op when storage is nil
-        await queue.setOfflineOverflowEnabled(true)
-
         // Events beyond capacity should just be dropped (existing behavior)
         for i in 0..<5 {
             await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
@@ -745,8 +702,43 @@ final class PersistentEventQueueTests: XCTestCase {
         let count = await queue.count
         XCTAssertEqual(count, 3)
 
-        let overflowCount = await queue.overflowCount()
-        XCTAssertEqual(overflowCount, 0, "No overflow should exist without overflow storage")
+        // No overflow disk → flushToOverflowDisk is a no-op
+        let flushed = await queue.flushToOverflowDisk()
+        XCTAssertFalse(flushed, "No overflow should exist without overflow storage")
+    }
+
+    func testFlushToOverflowDiskDrainsMemoryQueue() async throws {
+        let overflowDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExplicitFlushTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: overflowDir) }
+
+        let queue = PersistentEventQueue(
+            diskStorage: DiskStorage(baseDirectory: tempDir),
+            maxEventCount: 100,
+            overflowDiskStorage: DiskStorage(baseDirectory: overflowDir, fileName: "overflow.v1.json"),
+            maxOfflineDiskEvents: 10000
+        )
+
+        // Enqueue events (below capacity, so no automatic flush)
+        for i in 0..<5 {
+            await queue.enqueue(makeTestEvent(messageId: "e\(i)"))
+        }
+
+        let memBefore = await queue.count
+        XCTAssertEqual(memBefore, 5)
+
+        // Explicitly flush to overflow disk (e.g., when dispatcher detects offline)
+        let flushed = await queue.flushToOverflowDisk()
+        XCTAssertTrue(flushed)
+
+        // Memory should be empty
+        let memAfter = await queue.count
+        XCTAssertEqual(memAfter, 0)
+
+        // Overflow disk should have all events
+        let overflowBatch = await queue.readOverflowBatch(max: 10)
+        XCTAssertEqual(overflowBatch.count, 5)
+        XCTAssertEqual(overflowBatch.map(\.messageId), ["e0", "e1", "e2", "e3", "e4"])
     }
 }
 


### PR DESCRIPTION
## Summary

Adds network-awareness to the SDK: offline detection, crash-safety, debounced transitions, and extended-offline disk overflow. Memory is the fast path; a single on-disk snapshot (`queue.v1.json`) serves both crash-safety and extended-offline overflow.

Ticket: https://app.shortcut.com/metarouter/story/36908

## Design evolution (since original PR body)

Earlier iterations had a separate `overflow.v1.json` plus an in-memory overflow buffer. Those were consolidated — the same `DiskStorage` now serves both runtime overflow (memory at capacity while offline) and crash-safety snapshots (app background / kill). This removes duplicate queuing logic and aligns with the JS/Android SDKs.

## Key components

| Area | Responsibility |
|------|---------------|
| `NetworkMonitor` | `NWPathMonitor` wrapper + `reconcile()` for simulator-missed transitions |
| `DebouncedNetworkMonitor` | Immediate offline, 2s debounced online (flap protection) |
| `PersistentEventQueue` | Memory + disk, `AsyncMutex`-serialized flushes, byte+count thresholds, boot-time disk check |
| `DiskStorage` | Single-file snapshot, atomic write, `append()` with `maxEvents` cap |
| `Dispatcher` | `setOffline()` pause/resume, `drainDiskStoreToNetwork` with response-category handling |
| `AnalyticsClient` | Wires monitor → dispatcher, periodic reconciliation loop while offline |
| `InitOptions` | `maxQueueEvents` (default 2000), `maxDiskEvents` (default 10000) |

## Behavior

**Offline path**
1. `NWPathMonitor` signals disconnect → `DebouncedNetworkMonitor` fires immediately → `dispatcher.setOffline(true)`
2. Dispatcher cancels any pending retry timer, keeps accepting events
3. Periodic flush (10s) pushes memory to disk instead of the network (append, merge, cap enforcement)
4. While offline, `AnalyticsClient` runs a 10s reconcile loop to recover from `NWPathMonitor` misses (common on simulator)

**Online path**
1. `NWPathMonitor` signals satisfied → 2s debounce for stability → `dispatcher.setOffline(false)`
2. Dispatcher resets circuit breaker + retry counter, then two parallel flush paths:
   - Memory queue → network (standard `flush()`)
   - Disk store → network via `drainDiskStoreToNetwork` (direct sends, bypasses memory)

**Drain protocol (`drainDiskStoreToNetwork`)**
- Acquires disk lock for the whole drain
- Reads-all + deletes in one actor hop (no suspends)
- Iterates batches in memory, checkpointing remainder every 10 successful batches
- Response handling: 413 halves batch size, 5xx/429 persists remainder and stops, 401/403/404 deletes disk store + fires fatal handler, network failure persists remainder and stops

**Lifecycle**
- App background: memory flushed to disk, flush loop stopped
- App relaunch: `checkForPersistedEvents()` sets `hasDiskData` without parsing; if online, drain kicks off

## Files changed

| File | Changes |
|------|---------|
| `Sources/MetaRouter/analytics/AnalyticsClient.swift` | Wires debounced monitor, reconcile loop, drain on launch |
| `Sources/MetaRouter/analytics/InitOptions.swift` | `maxQueueEvents`, `maxDiskEvents` knobs |
| `Sources/MetaRouter/network/NetworkMonitor.swift` | `NetworkReachability` protocol + `reconcile()` |
| `Sources/MetaRouter/network/DebouncedNetworkMonitor.swift` | New: asymmetric debounce wrapper |
| `Sources/MetaRouter/network/Dispatcher.swift` | `setOffline`, `drainDiskStoreToNetwork`, `sendBatchDirect`, `isDraining` guard |
| `Sources/MetaRouter/queue/DiskStorage.swift` | Atomic write, `append(_:maxEvents:)`, backup-excluded dir |
| `Sources/MetaRouter/queue/PersistentEventQueue.swift` | Memory + disk, disk-lock, byte threshold, TTL constant |
| `Sources/MetaRouter/utils/AsyncMutex.swift` | New: async mutex used to serialize flush vs drain |
| `Tests/MetaRouterTests/DispatcherTests.swift` | Drain / offline-transition tests |
| `Tests/MetaRouterTests/PersistentEventQueueTests.swift` | Memory/disk coordination tests |
| `Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift` | Debounce behavior |
| `Tests/MetaRouterTests/NetworkMonitorTests.swift` | Reachability + reconcile |

## Test plan

- [x] Full test suite passing
- [x] Simulator: events flush to disk while offline (no network calls)
- [x] Simulator: offline → online triggers memory flush + disk drain
- [x] Simulator: `NWPathMonitor` missed-transition recovered by reconcile loop
- [x] App-background while offline → disk persists events
- [x] Relaunch while online → drain fires via `checkForPersistedEvents()` path
- [x] 413 halves batch size; 5xx/429 persists remainder; 401/403/404 clears disk + fires fatal

## Follow-ups (not in this PR)

- Append-only NDJSON disk format to eliminate O(n²) write amplification on long offline stretches. Sketch saved locally; low priority for ecommerce workloads (rarely offline long).

