### PR TITLE
feat: expose getAnonymousId

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The analytics client provides the following methods:
 - `alias(_ newUserId: String)`: Connect anonymous users to known user IDs. See [Using the alias() Method](#using-the-alias-method) for details
 - `setAdvertisingId(_ advertisingId: String?)`: Set the advertising identifier (IDFA) for ad tracking. See [Advertising ID](#advertising-id-idfa) section for usage and compliance requirements
 - `clearAdvertisingId()`: Clear the advertising identifier from storage and context. Useful for GDPR/CCPA compliance when users opt out of ad tracking
+- `getAnonymousId() async -> String`: Retrieve the device's anonymous ID. Awaits initialization internally so the returned value is always valid — never nil or empty
 - `flush()`: Flush events immediately
 - `reset()`: Reset analytics state and clear all stored data (includes clearing advertising ID)
 - `enableDebugLogging()`: Enable debug logging

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -28,6 +28,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
     private var lifecycle: AppLifecycleObserver?
     private var lifecycleState: LifecycleState = .idle
     private var disabled = false
+    private var initTask: Task<Void, Never>?
 
     private init(options: InitOptions, deps: AnalyticsDependencies = .production) {
         self.lifecycleState = .initializing
@@ -109,7 +110,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             }
         }
 
-        Task { [weak self] in
+        self.initTask = Task { [weak self] in
             guard let self else { return }
             await self.identityManager.initialize()
 
@@ -313,8 +314,9 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             host: options.ingestionHost.absoluteString)
     }
 
-    public func getAnonymousId() async -> String? {
-        return await identityManager.getAnonymousId()
+    public func getAnonymousId() async -> String {
+        await initTask?.value
+        return await identityManager.getAnonymousId() ?? UUID().uuidString.lowercased()
     }
 
     public func getDebugInfo() async -> [String: CodableValue] {

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -313,6 +313,10 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             host: options.ingestionHost.absoluteString)
     }
 
+    public func getAnonymousId() async -> String? {
+        return await identityManager.getAnonymousId()
+    }
+
     public func getDebugInfo() async -> [String: CodableValue] {
         // Mask writeKey to show only last 4 characters
         let maskedKey = options.writeKey.count > 4 

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -316,7 +316,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
 
     public func getAnonymousId() async -> String {
         await initTask?.value
-        return await identityManager.getAnonymousId() ?? UUID().uuidString.lowercased()
+        return await identityManager.getOrCreateAnonymousId()
     }
 
     public func getDebugInfo() async -> [String: CodableValue] {

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -387,6 +387,7 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
             await self.dispatcher.stopFlushLoop()
             await self.dispatcher.cancelScheduledRetry()
             await self.dispatcher.clearAll()
+            self.initTask = nil
             self.disabled = false
             self.lifecycleState = .idle
         }

--- a/Sources/MetaRouter/analytics/AnalyticsInterface.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsInterface.swift
@@ -18,6 +18,7 @@ public protocol AnalyticsInterface: AnyObject, Sendable {
 
     func alias(_ newUserId: String)
     func enableDebugLogging()
+    func getAnonymousId() async -> String?
     func getDebugInfo() async -> [String: CodableValue]
     func flush()
     func reset()

--- a/Sources/MetaRouter/analytics/AnalyticsInterface.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsInterface.swift
@@ -18,7 +18,7 @@ public protocol AnalyticsInterface: AnyObject, Sendable {
 
     func alias(_ newUserId: String)
     func enableDebugLogging()
-    func getAnonymousId() async -> String?
+    func getAnonymousId() async -> String
     func getDebugInfo() async -> [String: CodableValue]
     func flush()
     func reset()

--- a/Sources/MetaRouter/analytics/AnalyticsProxy.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsProxy.swift
@@ -83,7 +83,7 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
         Task { await state.enqueue(.enableDebugLogging) }
     }
 
-    public func getAnonymousId() async -> String? {
+    public func getAnonymousId() async -> String {
         return await state.getAnonymousId()
     }
 
@@ -135,17 +135,30 @@ private actor ProxyState {
     private var queue: [Call] = []
     private let cap = 20
     private var bootstrapDebugInfo: [String: CodableValue] = [:]
+    private var bindContinuations: [CheckedContinuation<AnalyticsInterface, Never>] = []
 
     func bind(_ client: AnalyticsInterface) {
         real = client
         // Replay queued calls
         for call in queue { forward(call) }
         queue.removeAll()
+        // Resume any callers waiting for binding
+        for continuation in bindContinuations {
+            continuation.resume(returning: client)
+        }
+        bindContinuations.removeAll()
     }
 
     func unbind() {
         real = nil
         queue.removeAll()
+    }
+
+    private func awaitClient() async -> AnalyticsInterface {
+        if let client = real { return client }
+        return await withCheckedContinuation { continuation in
+            bindContinuations.append(continuation)
+        }
     }
 
     func enqueue(_ call: Call) {
@@ -167,11 +180,9 @@ private actor ProxyState {
         ]
     }
 
-    func getAnonymousId() async -> String? {
-        if let client = real {
-            return await client.getAnonymousId()
-        }
-        return nil
+    func getAnonymousId() async -> String {
+        let client = await awaitClient()
+        return await client.getAnonymousId()
     }
 
     func getDebugInfo() async -> [String: CodableValue] {

--- a/Sources/MetaRouter/analytics/AnalyticsProxy.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsProxy.swift
@@ -83,6 +83,10 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
         Task { await state.enqueue(.enableDebugLogging) }
     }
 
+    public func getAnonymousId() async -> String? {
+        return await state.getAnonymousId()
+    }
+
     public func getDebugInfo() async -> [String: CodableValue] {
         return await state.getDebugInfo()
     }
@@ -161,6 +165,13 @@ private actor ProxyState {
             "writeKey": .string(maskedKey),
             "ingestionHost": .string(host),
         ]
+    }
+
+    func getAnonymousId() async -> String? {
+        if let client = real {
+            return await client.getAnonymousId()
+        }
+        return nil
     }
 
     func getDebugInfo() async -> [String: CodableValue] {

--- a/Sources/MetaRouter/identity/IdentityManager.swift
+++ b/Sources/MetaRouter/identity/IdentityManager.swift
@@ -24,7 +24,7 @@ public actor IdentityManager {
     /// Initializes the manager by loading or generating an anonymous ID.
     /// Should be called before using other methods.
     public func initialize() async {
-        _ = getOrCreateAnonymousId()
+        getOrCreateAnonymousId()
 
         // Load userId, groupId, and advertisingId if they exist
         self.userId = storage.get(.userId)
@@ -49,6 +49,7 @@ public actor IdentityManager {
     /// Returns the current anonymous ID, generating and persisting one if missing.
     /// Safe to call before `initialize()` or after `reset()` — guarantees a stable,
     /// persisted ID across subsequent calls.
+    @discardableResult
     public func getOrCreateAnonymousId() -> String {
         if let existing = anonymousId {
             return existing

--- a/Sources/MetaRouter/identity/IdentityManager.swift
+++ b/Sources/MetaRouter/identity/IdentityManager.swift
@@ -24,17 +24,8 @@ public actor IdentityManager {
     /// Initializes the manager by loading or generating an anonymous ID.
     /// Should be called before using other methods.
     public func initialize() async {
-        // Load anonymous ID or generate a new one
-        if let storedAnonId = storage.get(.anonymousId) {
-            self.anonymousId = storedAnonId
-            Logger.log("Loaded stored anonymous ID: \(storedAnonId)", writeKey: writeKey, host: host)
-        } else {
-            let newId = UUID().uuidString.lowercased()
-            storage.set(.anonymousId, value: newId)
-            self.anonymousId = newId
-            Logger.log("Generated and stored new anonymous ID: \(newId)", writeKey: writeKey, host: host)
-        }
-        
+        _ = getOrCreateAnonymousId()
+
         // Load userId, groupId, and advertisingId if they exist
         self.userId = storage.get(.userId)
         self.groupId = storage.get(.groupId)
@@ -53,6 +44,25 @@ public actor IdentityManager {
     /// Retrieves the current anonymous ID.
     public func getAnonymousId() -> String? {
         return anonymousId
+    }
+
+    /// Returns the current anonymous ID, generating and persisting one if missing.
+    /// Safe to call before `initialize()` or after `reset()` — guarantees a stable,
+    /// persisted ID across subsequent calls.
+    public func getOrCreateAnonymousId() -> String {
+        if let existing = anonymousId {
+            return existing
+        }
+        if let stored = storage.get(.anonymousId) {
+            self.anonymousId = stored
+            Logger.log("Loaded stored anonymous ID: \(stored)", writeKey: writeKey, host: host)
+            return stored
+        }
+        let newId = UUID().uuidString.lowercased()
+        storage.set(.anonymousId, value: newId)
+        self.anonymousId = newId
+        Logger.log("Generated and stored new anonymous ID: \(newId)", writeKey: writeKey, host: host)
+        return newId
     }
     
     /// Sets the user ID for the current session.

--- a/Tests/MetaRouterTests/AnalyticsClientTests.swift
+++ b/Tests/MetaRouterTests/AnalyticsClientTests.swift
@@ -565,12 +565,8 @@ final class AnalyticsClientTests: XCTestCase {
     }
 
     func testGetAnonymousIdReturnsValueAfterInitialization() async {
-        // Wait for the client to finish initialization
-        try? await Task.sleep(nanoseconds: 500_000_000)
-
         let anonymousId = await client.getAnonymousId()
-        XCTAssertNotNil(anonymousId, "Anonymous ID should be non-nil after initialization")
-        XCTAssertFalse(anonymousId!.isEmpty, "Anonymous ID should not be empty")
+        XCTAssertFalse(anonymousId.isEmpty, "Anonymous ID should not be empty")
     }
 
     func testGetAnonymousIdMatchesIdentityManager() async {
@@ -592,9 +588,6 @@ final class AnalyticsClientTests: XCTestCase {
         deps.identityManager = identityManager
         let testClient = AnalyticsClient.initialize(options: options, deps: deps)
 
-        // Wait for initialization
-        try? await Task.sleep(nanoseconds: 500_000_000)
-
         let clientAnonymousId = await testClient.getAnonymousId()
         let managerAnonymousId = await identityManager.getAnonymousId()
         XCTAssertEqual(clientAnonymousId, managerAnonymousId,
@@ -604,13 +597,9 @@ final class AnalyticsClientTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
-    func testGetAnonymousIdReturnsNilAfterReset() async {
-        // Wait for initialization to complete
-        try? await Task.sleep(nanoseconds: 500_000_000)
-
-        // Verify we have an anonymous ID before reset
+    func testGetAnonymousIdReturnsNewValueAfterReset() async {
         let preResetId = await client.getAnonymousId()
-        XCTAssertNotNil(preResetId, "Should have anonymous ID before reset")
+        XCTAssertFalse(preResetId.isEmpty, "Should have anonymous ID before reset")
 
         // Reset the client
         client.reset()
@@ -619,7 +608,8 @@ final class AnalyticsClientTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 500_000_000)
 
         let postResetId = await client.getAnonymousId()
-        XCTAssertNil(postResetId, "Anonymous ID should be nil after reset")
+        XCTAssertFalse(postResetId.isEmpty, "Anonymous ID should still be available after reset")
+        XCTAssertNotEqual(preResetId, postResetId, "Anonymous ID should change after reset")
     }
 
     func testGetDebugInfoIncludesNetworkStatus() async {

--- a/Tests/MetaRouterTests/AnalyticsClientTests.swift
+++ b/Tests/MetaRouterTests/AnalyticsClientTests.swift
@@ -564,6 +564,64 @@ final class AnalyticsClientTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 2.0)
     }
 
+    func testGetAnonymousIdReturnsValueAfterInitialization() async {
+        // Wait for the client to finish initialization
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        let anonymousId = await client.getAnonymousId()
+        XCTAssertNotNil(anonymousId, "Anonymous ID should be non-nil after initialization")
+        XCTAssertFalse(anonymousId!.isEmpty, "Anonymous ID should not be empty")
+    }
+
+    func testGetAnonymousIdMatchesIdentityManager() async {
+        // Create a dedicated UserDefaults suite with a pre-seeded anonymous ID
+        let suiteName = "com.metarouter.test.getAnonymousId.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let knownId = UUID().uuidString
+        defaults.set(knownId, forKey: IdentityStorageKey.anonymousId.rawValue)
+
+        let storage = IdentityStorage(userDefaults: defaults)
+        let identityManager = IdentityManager(
+            storage: storage,
+            writeKey: "test-write-key",
+            host: "https://test.metarouter.com"
+        )
+        await identityManager.initialize()
+
+        var deps = AnalyticsDependencies()
+        deps.identityManager = identityManager
+        let testClient = AnalyticsClient.initialize(options: options, deps: deps)
+
+        // Wait for initialization
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        let clientAnonymousId = await testClient.getAnonymousId()
+        let managerAnonymousId = await identityManager.getAnonymousId()
+        XCTAssertEqual(clientAnonymousId, managerAnonymousId,
+                       "Client getAnonymousId should return the same value as IdentityManager")
+        XCTAssertEqual(clientAnonymousId, knownId)
+
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testGetAnonymousIdReturnsNilAfterReset() async {
+        // Wait for initialization to complete
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        // Verify we have an anonymous ID before reset
+        let preResetId = await client.getAnonymousId()
+        XCTAssertNotNil(preResetId, "Should have anonymous ID before reset")
+
+        // Reset the client
+        client.reset()
+
+        // Wait for reset to propagate
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        let postResetId = await client.getAnonymousId()
+        XCTAssertNil(postResetId, "Anonymous ID should be nil after reset")
+    }
+
     func testGetDebugInfoIncludesNetworkStatus() async {
         let stubMonitor = StubNetworkMonitor(status: .connected)
         let deps = AnalyticsDependencies(networkMonitor: stubMonitor)

--- a/Tests/MetaRouterTests/AnalyticsProxyTests.swift
+++ b/Tests/MetaRouterTests/AnalyticsProxyTests.swift
@@ -391,6 +391,20 @@ final class AnalyticsProxyTests: XCTestCase {
         XCTAssertEqual(mockClient2.callCount, 1)
     }
     
+    func testGetAnonymousIdWhenNotBoundReturnsNil() async {
+        let anonymousId = await proxy.getAnonymousId()
+        XCTAssertNil(anonymousId, "Anonymous ID should be nil when proxy is not bound")
+    }
+
+    func testGetAnonymousIdWhenBoundDelegatesToRealClient() async {
+        mockClient.anonymousIdToReturn = "anon-123"
+        await proxy._bindAndReplay(mockClient)
+
+        let anonymousId = await proxy.getAnonymousId()
+        XCTAssertEqual(anonymousId, "anon-123", "Should return the value from the bound client")
+        XCTAssertTrue(mockClient.calls.contains(.getAnonymousId), "Should have called getAnonymousId on the mock")
+    }
+
     func testCallsWithNilValues() async {
         proxy.bind(mockClient)
         

--- a/Tests/MetaRouterTests/AnalyticsProxyTests.swift
+++ b/Tests/MetaRouterTests/AnalyticsProxyTests.swift
@@ -391,17 +391,28 @@ final class AnalyticsProxyTests: XCTestCase {
         XCTAssertEqual(mockClient2.callCount, 1)
     }
     
-    func testGetAnonymousIdWhenNotBoundReturnsNil() async {
-        let anonymousId = await proxy.getAnonymousId()
-        XCTAssertNil(anonymousId, "Anonymous ID should be nil when proxy is not bound")
+    func testGetAnonymousIdAwaitsBindingThenDelegates() async {
+        mockClient.anonymousIdToReturn = "anon-123"
+
+        // Start getAnonymousId before binding — it should suspend until bound
+        let proxy = self.proxy!
+        let resultTask = Task { await proxy.getAnonymousId() }
+
+        // Bind after a short delay so the await above is already waiting
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        await proxy._bindAndReplay(mockClient)
+
+        let result = await resultTask.value
+        XCTAssertEqual(result, "anon-123", "Should return the value from the bound client")
+        XCTAssertTrue(mockClient.calls.contains(.getAnonymousId), "Should have called getAnonymousId on the mock")
     }
 
-    func testGetAnonymousIdWhenBoundDelegatesToRealClient() async {
-        mockClient.anonymousIdToReturn = "anon-123"
+    func testGetAnonymousIdWhenAlreadyBoundDelegatesImmediately() async {
+        mockClient.anonymousIdToReturn = "anon-456"
         await proxy._bindAndReplay(mockClient)
 
         let anonymousId = await proxy.getAnonymousId()
-        XCTAssertEqual(anonymousId, "anon-123", "Should return the value from the bound client")
+        XCTAssertEqual(anonymousId, "anon-456", "Should return the value from the bound client")
         XCTAssertTrue(mockClient.calls.contains(.getAnonymousId), "Should have called getAnonymousId on the mock")
     }
 

--- a/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
+++ b/Tests/MetaRouterTests/DebouncedNetworkMonitorTests.swift
@@ -99,8 +99,11 @@ final class DebouncedNetworkMonitorTests: XCTestCase {
         XCTAssertEqual(recorder.statuses, [.disconnected])
 
         stub.simulate(.connected)
-        try? await Task.sleep(nanoseconds: 200_000_000)
-        XCTAssertEqual(recorder.statuses, [.disconnected, .connected])
+        let onlineFired = await TestUtilities.waitFor(timeout: 3.0) {
+            recorder.statuses == [.disconnected, .connected]
+        }
+        XCTAssertTrue(onlineFired,
+            "Expected debounced online transition to fire; got \(recorder.statuses)")
 
         stub.simulate(.disconnected)
         XCTAssertEqual(recorder.statuses, [.disconnected, .connected, .disconnected])

--- a/Tests/MetaRouterTests/Helpers/TestHelpers.swift
+++ b/Tests/MetaRouterTests/Helpers/TestHelpers.swift
@@ -64,7 +64,7 @@ final class MockAnalyticsInterface: AnalyticsInterface, @unchecked Sendable {
         _calls.append(call)
     }
 
-    var anonymousIdToReturn: String?
+    var anonymousIdToReturn: String = "mock-anonymous-id"
 
     // AnalyticsInterface Implementation
 
@@ -126,7 +126,7 @@ final class MockAnalyticsInterface: AnalyticsInterface, @unchecked Sendable {
         recordCall(.enableDebugLogging)
     }
 
-    func getAnonymousId() async -> String? {
+    func getAnonymousId() async -> String {
         recordCall(.getAnonymousId)
         return anonymousIdToReturn
     }

--- a/Tests/MetaRouterTests/Helpers/TestHelpers.swift
+++ b/Tests/MetaRouterTests/Helpers/TestHelpers.swift
@@ -64,6 +64,8 @@ final class MockAnalyticsInterface: AnalyticsInterface, @unchecked Sendable {
         _calls.append(call)
     }
 
+    var anonymousIdToReturn: String?
+
     // AnalyticsInterface Implementation
 
     func track(_ event: String, properties: [String: Any]?) {
@@ -124,6 +126,11 @@ final class MockAnalyticsInterface: AnalyticsInterface, @unchecked Sendable {
         recordCall(.enableDebugLogging)
     }
 
+    func getAnonymousId() async -> String? {
+        recordCall(.getAnonymousId)
+        return anonymousIdToReturn
+    }
+
     func getDebugInfo() async -> [String: CodableValue] {
         recordCall(.getDebugInfo)
         return ["mock": "debug-info"]
@@ -160,6 +167,7 @@ enum AnalyticsCall: Equatable {
     case page(name: String, properties: [String: CodableValue]?)
     case alias(newUserId: String)
     case enableDebugLogging
+    case getAnonymousId
     case getDebugInfo
 
     case flush

--- a/Tests/MetaRouterTests/MetaRouterIntegrationTests.swift
+++ b/Tests/MetaRouterTests/MetaRouterIntegrationTests.swift
@@ -607,8 +607,7 @@ final class MetaRouterIntegrationTests: XCTestCase {
         let client: AnalyticsInterface = await MetaRouter.Analytics.initializeAndWait(with: options)
 
         let anonymousId = await client.getAnonymousId()
-        XCTAssertNotNil(anonymousId, "Anonymous ID should be available after initialization")
-        XCTAssertFalse(anonymousId!.isEmpty, "Anonymous ID should not be empty")
+        XCTAssertFalse(anonymousId.isEmpty, "Anonymous ID should not be empty")
     }
 
     func testGDPRComplianceWorkflow() async {

--- a/Tests/MetaRouterTests/MetaRouterIntegrationTests.swift
+++ b/Tests/MetaRouterTests/MetaRouterIntegrationTests.swift
@@ -602,6 +602,15 @@ final class MetaRouterIntegrationTests: XCTestCase {
         XCTAssertTrue(true, "Multiple clearAdvertisingId calls should be handled safely")
     }
 
+    func testGetAnonymousIdThroughPublicInterface() async {
+        let options = TestDataFactory.makeInitOptions()
+        let client: AnalyticsInterface = await MetaRouter.Analytics.initializeAndWait(with: options)
+
+        let anonymousId = await client.getAnonymousId()
+        XCTAssertNotNil(anonymousId, "Anonymous ID should be available after initialization")
+        XCTAssertFalse(anonymousId!.isEmpty, "Anonymous ID should not be empty")
+    }
+
     func testGDPRComplianceWorkflow() async {
         let options = TestDataFactory.makeInitOptions()
         let client = await MetaRouter.Analytics.initializeAndWait(with: options)


### PR DESCRIPTION
## Summary

- `getAnonymousId()` returns `String` 
- `AnalyticsClient` stores the background init `Task` and awaits it in `getAnonymousId()`, addressing a race condition where the identity manager hadn't finished initializing
- `AnalyticsProxy` uses a `CheckedContinuation`-based wait: if the proxy isn't bound yet, `getAnonymousId()` suspends until `bind()` is called rather than returning nil
- No new `Call` case  this is a read/barrier API like `getDebugInfo()`, not a queued operation

Ticket: https://app.shortcut.com/metarouter/story/37838

## Test plan

- [x] `testGetAnonymousIdReturnsValueAfterInitialization` — client awaits init, returns non-empty ID (no sleep needed)
- [x] `testGetAnonymousIdMatchesIdentityManager` — client value matches injected IdentityManager with pre-seeded ID
- [x] `testGetAnonymousIdReturnsNewValueAfterReset` — returns a new generated ID after `reset()`, not nil
- [x] `testGetAnonymousIdAwaitsBindingThenDelegates` — proxy suspends until bound, then delegates to mock
- [x] `testGetAnonymousIdWhenAlreadyBoundDelegatesImmediately` — proxy forwards immediately when already bound
- [x] `testGetAnonymousIdThroughPublicInterface` — integration test via `MetaRouter.Analytics.initializeAndWait`
- [x] All 386 existing tests pass with 0 failures