### PR TITLE
feat(lifecycle): storage + bundle metadata foundation [1/4]

### DIFF
--- a/Sources/MetaRouter/identity/IdentityStorage.swift
+++ b/Sources/MetaRouter/identity/IdentityStorage.swift
@@ -38,5 +38,16 @@ public struct IdentityStorage: @unchecked Sendable {
         remove(.groupId)
         remove(.advertisingId)
     }
+
+    /// Returns `true` if any identity field is currently persisted.
+    /// Used by `LifecycleEventEmitter` to differentiate a true fresh install
+    /// (no identity, no lifecycle storage) from an existing user upgrading from
+    /// a pre-lifecycle SDK build (identity present, no lifecycle storage).
+    public func hasAnyValue() -> Bool {
+        return get(.anonymousId) != nil
+            || get(.userId) != nil
+            || get(.groupId) != nil
+            || get(.advertisingId) != nil
+    }
 }
 

--- a/Sources/MetaRouter/lifecycle/AppForegroundState.swift
+++ b/Sources/MetaRouter/lifecycle/AppForegroundState.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Process-level foreground state used to gate cold-launch and resume emits
+/// in the lifecycle subsystem. Mirrors `UIApplication.State` (and the AppKit
+/// equivalent) but is platform-neutral so non-UI code can pass it across
+/// actor / Task boundaries.
+public enum AppForegroundState: Sendable, Equatable {
+    case active
+    case inactive
+    case background
+}

--- a/Sources/MetaRouter/types/EventContext.swift
+++ b/Sources/MetaRouter/types/EventContext.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-/// App-specific context information
-public struct AppContext: Codable, Sendable {
+/// App-specific context information. Cached once at SDK init from the bundle
+/// (see `fromBundle`) — `Bundle.main.infoDictionary` is OS-loaded at process
+/// start and immutable, so the cached value is stable for the SDK lifetime.
+public struct AppContext: Codable, Sendable, Equatable {
     public let name: String
     public let version: String
     public let build: String
@@ -12,6 +14,19 @@ public struct AppContext: Codable, Sendable {
         self.version = version
         self.build = build
         self.namespace = namespace
+    }
+
+    public static func fromBundle(_ bundle: Bundle = .main) -> AppContext {
+        let info = bundle.infoDictionary ?? [:]
+        let name = (info["CFBundleDisplayName"] as? String)
+            ?? (info["CFBundleName"] as? String)
+            ?? "Unknown"
+        return AppContext(
+            name: name,
+            version: info["CFBundleShortVersionString"] as? String ?? "unknown",
+            build: info["CFBundleVersion"] as? String ?? "unknown",
+            namespace: bundle.bundleIdentifier ?? "unknown"
+        )
     }
 }
 

--- a/Sources/MetaRouter/utils/LifecycleStorage.swift
+++ b/Sources/MetaRouter/utils/LifecycleStorage.swift
@@ -42,8 +42,11 @@ public struct LifecycleStorage: @unchecked Sendable {
         setBuild(build)
     }
 
-    /// Removes the persisted version and build. Intended for tests.
-    public func clear() {
+    /// Removes the persisted version and build. Test-only seam — production code
+    /// must never call this. The whole point of the `metarouter:lifecycle:*`
+    /// namespace separation is that nothing — not even `reset()` — can wipe
+    /// install/update state.
+    internal func clear() {
         userDefaults.removeObject(forKey: LifecycleStorageKey.version.rawValue)
         userDefaults.removeObject(forKey: LifecycleStorageKey.build.rawValue)
     }

--- a/Sources/MetaRouter/utils/LifecycleStorage.swift
+++ b/Sources/MetaRouter/utils/LifecycleStorage.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Keys for persisting the last-seen application version/build in UserDefaults.
+/// These keys live in a namespace separate from `IdentityStorageKey` so they
+/// are unaffected by `IdentityStorage.clear()` (and therefore by `reset()`).
+public enum LifecycleStorageKey: String {
+    case version = "metarouter:lifecycle:version"
+    case build = "metarouter:lifecycle:build"
+}
+
+/// Persists the last application version/build the SDK observed on cold launch.
+/// Used by `LifecycleEventEmitter` to decide whether to emit `Application Installed`
+/// or `Application Updated`.
+///
+/// Storage is kept intentionally separate from `IdentityStorage` so a user's
+/// `reset()` call cannot wipe install/update state.
+public struct LifecycleStorage: @unchecked Sendable {
+    private let userDefaults: UserDefaults
+
+    public init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    public func getVersion() -> String? {
+        return userDefaults.string(forKey: LifecycleStorageKey.version.rawValue)
+    }
+
+    public func getBuild() -> String? {
+        return userDefaults.string(forKey: LifecycleStorageKey.build.rawValue)
+    }
+
+    public func setVersion(_ value: String) {
+        userDefaults.set(value, forKey: LifecycleStorageKey.version.rawValue)
+    }
+
+    public func setBuild(_ value: String) {
+        userDefaults.set(value, forKey: LifecycleStorageKey.build.rawValue)
+    }
+
+    public func setVersionBuild(version: String, build: String) {
+        setVersion(version)
+        setBuild(build)
+    }
+
+    /// Removes the persisted version and build. Intended for tests.
+    public func clear() {
+        userDefaults.removeObject(forKey: LifecycleStorageKey.version.rawValue)
+        userDefaults.removeObject(forKey: LifecycleStorageKey.build.rawValue)
+    }
+}

--- a/Sources/MetaRouter/utils/LifecycleStorage.swift
+++ b/Sources/MetaRouter/utils/LifecycleStorage.swift
@@ -29,17 +29,13 @@ public struct LifecycleStorage: @unchecked Sendable {
         return userDefaults.string(forKey: LifecycleStorageKey.build.rawValue)
     }
 
-    public func setVersion(_ value: String) {
-        userDefaults.set(value, forKey: LifecycleStorageKey.version.rawValue)
-    }
-
-    public func setBuild(_ value: String) {
-        userDefaults.set(value, forKey: LifecycleStorageKey.build.rawValue)
-    }
-
+    /// Version and build are persisted together to keep them in lockstep — the
+    /// lifecycle emitter treats `(version, build)` as a pair, so independent
+    /// setters would let the two halves drift and trigger spurious
+    /// `Application Updated` events on the next cold launch.
     public func setVersionBuild(version: String, build: String) {
-        setVersion(version)
-        setBuild(build)
+        userDefaults.set(version, forKey: LifecycleStorageKey.version.rawValue)
+        userDefaults.set(build, forKey: LifecycleStorageKey.build.rawValue)
     }
 
     /// Removes the persisted version and build. Test-only seam — production code

--- a/Tests/MetaRouterTests/IdentityStorageTests.swift
+++ b/Tests/MetaRouterTests/IdentityStorageTests.swift
@@ -177,8 +177,21 @@ final class IdentityStorageTests: XCTestCase {
     func testSetUnicodeCharacters() {
         let unicodeString = "用户-123-🎉"
         storage.set(.userId, value: unicodeString)
-        
+
         XCTAssertEqual(storage.get(.userId), unicodeString)
+    }
+
+    func testHasAnyValueDetectsAnyKey() {
+        XCTAssertFalse(storage.hasAnyValue())
+
+        storage.set(.anonymousId, value: "abc")
+        XCTAssertTrue(storage.hasAnyValue())
+
+        storage.clear()
+        XCTAssertFalse(storage.hasAnyValue())
+
+        storage.set(.userId, value: "u")
+        XCTAssertTrue(storage.hasAnyValue())
     }
 }
 

--- a/Tests/MetaRouterTests/LifecycleStorageTests.swift
+++ b/Tests/MetaRouterTests/LifecycleStorageTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import MetaRouter
+
+final class LifecycleStorageTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.metarouter.test.lifecycleStorage.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testRoundTripVersionAndBuild() {
+        let storage = LifecycleStorage(userDefaults: defaults)
+
+        XCTAssertNil(storage.getVersion())
+        XCTAssertNil(storage.getBuild())
+
+        storage.setVersion("1.5.0")
+        storage.setBuild("42")
+
+        XCTAssertEqual(storage.getVersion(), "1.5.0")
+        XCTAssertEqual(storage.getBuild(), "42")
+    }
+
+    func testSetVersionBuildHelperSetsBoth() {
+        let storage = LifecycleStorage(userDefaults: defaults)
+        storage.setVersionBuild(version: "2.0.0", build: "100")
+
+        XCTAssertEqual(storage.getVersion(), "2.0.0")
+        XCTAssertEqual(storage.getBuild(), "100")
+    }
+
+    func testClearRemovesBothKeys() {
+        let storage = LifecycleStorage(userDefaults: defaults)
+        storage.setVersionBuild(version: "1.0", build: "1")
+        storage.clear()
+
+        XCTAssertNil(storage.getVersion())
+        XCTAssertNil(storage.getBuild())
+    }
+
+    /// Lifecycle storage uses the `metarouter:lifecycle:*` key prefix and is
+    /// NOT enumerated by `IdentityStorage.clear()`. This is the structural
+    /// guarantee that `reset()` cannot wipe install/update state.
+    func testIdentityStorageClearDoesNotTouchLifecycleKeys() {
+        // Seed both stores on the same backing UserDefaults
+        let identityStorage = IdentityStorage(userDefaults: defaults)
+        identityStorage.set(.anonymousId, value: "abc")
+        identityStorage.set(.userId, value: "user-1")
+
+        let lifecycleStorage = LifecycleStorage(userDefaults: defaults)
+        lifecycleStorage.setVersionBuild(version: "1.5.0", build: "42")
+
+        // Clearing identity must not touch lifecycle
+        identityStorage.clear()
+
+        XCTAssertNil(identityStorage.get(.anonymousId), "identity cleared")
+        XCTAssertNil(identityStorage.get(.userId), "identity cleared")
+        XCTAssertEqual(lifecycleStorage.getVersion(), "1.5.0",
+                       "lifecycle storage must survive IdentityStorage.clear()")
+        XCTAssertEqual(lifecycleStorage.getBuild(), "42",
+                       "lifecycle storage must survive IdentityStorage.clear()")
+    }
+
+    func testKeysUseExpectedNamespace() {
+        XCTAssertEqual(LifecycleStorageKey.version.rawValue, "metarouter:lifecycle:version")
+        XCTAssertEqual(LifecycleStorageKey.build.rawValue, "metarouter:lifecycle:build")
+    }
+
+    func testIdentityStorageHasAnyValueDetectsAnyKey() {
+        let storage = IdentityStorage(userDefaults: defaults)
+        XCTAssertFalse(storage.hasAnyValue())
+
+        storage.set(.anonymousId, value: "abc")
+        XCTAssertTrue(storage.hasAnyValue())
+
+        storage.clear()
+        XCTAssertFalse(storage.hasAnyValue())
+
+        storage.set(.userId, value: "u")
+        XCTAssertTrue(storage.hasAnyValue())
+    }
+}

--- a/Tests/MetaRouterTests/LifecycleStorageTests.swift
+++ b/Tests/MetaRouterTests/LifecycleStorageTests.swift
@@ -24,19 +24,10 @@ final class LifecycleStorageTests: XCTestCase {
         XCTAssertNil(storage.getVersion())
         XCTAssertNil(storage.getBuild())
 
-        storage.setVersion("1.5.0")
-        storage.setBuild("42")
+        storage.setVersionBuild(version: "1.5.0", build: "42")
 
         XCTAssertEqual(storage.getVersion(), "1.5.0")
         XCTAssertEqual(storage.getBuild(), "42")
-    }
-
-    func testSetVersionBuildHelperSetsBoth() {
-        let storage = LifecycleStorage(userDefaults: defaults)
-        storage.setVersionBuild(version: "2.0.0", build: "100")
-
-        XCTAssertEqual(storage.getVersion(), "2.0.0")
-        XCTAssertEqual(storage.getBuild(), "100")
     }
 
     func testClearRemovesBothKeys() {
@@ -74,19 +65,5 @@ final class LifecycleStorageTests: XCTestCase {
     func testKeysUseExpectedNamespace() {
         XCTAssertEqual(LifecycleStorageKey.version.rawValue, "metarouter:lifecycle:version")
         XCTAssertEqual(LifecycleStorageKey.build.rawValue, "metarouter:lifecycle:build")
-    }
-
-    func testIdentityStorageHasAnyValueDetectsAnyKey() {
-        let storage = IdentityStorage(userDefaults: defaults)
-        XCTAssertFalse(storage.hasAnyValue())
-
-        storage.set(.anonymousId, value: "abc")
-        XCTAssertTrue(storage.hasAnyValue())
-
-        storage.clear()
-        XCTAssertFalse(storage.hasAnyValue())
-
-        storage.set(.userId, value: "u")
-        XCTAssertTrue(storage.hasAnyValue())
     }
 }


### PR DESCRIPTION
## Ticket
[sc-38228](https://app.shortcut.com/metarouter/story/38228) — iOS Lifecycle PR 1: storage + bundle metadata foundation
**Parent:** [sc-36764](https://app.shortcut.com/metarouter/story/36764)

## Summary

**Slice 1 of 4** of the iOS lifecycle events feature. This is the bottom of the stack — pure additions to the storage layer and shared types. **No behavior change to `AnalyticsClient`, no events emitted yet.**

## What's in

- **`Sources/MetaRouter/utils/LifecycleStorage.swift`** *(new)* — `UserDefaults` wrapper for `(version, build)` under the `metarouter:lifecycle:*` namespace, separate from identity keys. Will be consumed by the emitter in slice 2 to detect Install vs Update.
- **`Sources/MetaRouter/identity/IdentityStorage.swift`** — adds `hasAnyValue()` helper. Used by the emitter (slice 2) to snapshot identity presence at construction time, before `IdentityManager.initialize()` auto-creates an `anonymousId`.
- **`Sources/MetaRouter/lifecycle/AppForegroundState.swift`** *(new)* — platform-neutral `active`/`inactive`/`background` enum. Used by the emitter and coordinator to reason about app state across actor / Task boundaries without depending on UIKit.
- **`Sources/MetaRouter/types/EventContext.swift`** — `AppContext` gains `Equatable` conformance and a `fromBundle(_:)` static factory. This is the single source of truth for app metadata; in slice 3 it replaces the per-event `Bundle.main.infoDictionary` reads currently happening in `DeviceContextProvider`.
- **`Tests/MetaRouterTests/LifecycleStorageTests.swift`** *(new)* — round-trip + namespace-isolation coverage.

## What's not in

- The `LifecycleEventEmitter` actor body — slice 2.
- Any wiring into `AnalyticsClient` — slice 3.
- README docs — slice 4.

## Test plan

- [x] `swift build` clean.
- [x] `swift test` — 424 tests pass, 0 failures (was 410 on `main`; new tests are `LifecycleStorageTests`).

## Stack

1. **This PR** — storage + types foundation
2. [sc-38229](https://app.shortcut.com/metarouter/story/38229) — `LifecycleEventEmitter` actor + unit tests
3. [sc-38230](https://app.shortcut.com/metarouter/story/38230) — `AnalyticsClient` wiring + `openURL` public API + integration tests
4. [sc-38231](https://app.shortcut.com/metarouter/story/38231) — Documentation + structural cleanups

Each sub-PR builds on the previous. Feature stays gated behind `trackLifecycleEvents: false` (default) until slice 3, so partial-feature exposure on `main` is impossible.