### PR TITLE
feat: webview bridge envelope + validation foundation [1/4]

### DIFF
--- a/Sources/MetaRouter/types/EventContext.swift
+++ b/Sources/MetaRouter/types/EventContext.swift
@@ -124,6 +124,32 @@ public struct EventContext: Codable, Sendable {
     }
 }
 
+/// Web page facts for events that originate inside a webview. Only present on
+/// bridge-sourced events — native events have no page to describe. Matches the
+/// web SDK's context.page block so downstream config treats webview traffic the
+/// same as browser traffic.
+public struct PageContext: Codable, Sendable, Equatable {
+    public let url: String?
+    public let path: String?
+    public let search: String?
+    public let title: String?
+    public let referrer: String?
+
+    public init(
+        url: String? = nil,
+        path: String? = nil,
+        search: String? = nil,
+        title: String? = nil,
+        referrer: String? = nil
+    ) {
+        self.url = url
+        self.path = path
+        self.search = search
+        self.title = title
+        self.referrer = referrer
+    }
+}
+
 /// Protocol for context collection
 public protocol ContextProvider: Sendable {
     /// Collects and returns the current event context

--- a/Sources/MetaRouter/webview/BridgeEnvelope.swift
+++ b/Sources/MetaRouter/webview/BridgeEnvelope.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A validated web→native bridge envelope (contract v1).
+///
+/// Instances are only produced by `BridgeEnvelopeParser.parse` — construction implies the
+/// required-field, version, and type rules have already been enforced, so downstream code
+/// (merge, dedup) never re-validates.
+///
+/// `version`, `sentAt`, and `source` are contract fields carried but not yet consumed:
+/// `version` feeds the parser's compatibility gate, `sentAt` is the producer's untrusted
+/// clock (native sets the real timestamp at merge), and `source` distinguishes the
+/// injected wrapper from the future web-SDK producer.
+internal struct BridgeEnvelope: Sendable {
+    let version: Int
+    let messageId: String
+    /// Restricted to `EventType.track` and `EventType.page` in contract v1.
+    let type: EventType
+    let name: String
+    let properties: [String: CodableValue]
+    let sentAt: String?
+    /// Point-in-time page facts stamped by the wrapper at call time.
+    let page: PageContext?
+    let source: BridgeSource?
+}
+
+/// Producer identification — distinguishes the injected wrapper from the future
+/// web-SDK proxy mode (F2).
+internal struct BridgeSource: Sendable, Equatable {
+    let producer: String?
+    let wrapperVersion: String?
+}

--- a/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
+++ b/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
@@ -65,13 +65,18 @@ internal enum BridgeEnvelopeParser {
     // bounded in bytes, not just entry count — 1000 retained near-64KB ids would be ~64MB.
     static let maxMessageIdChars = 256
 
+    // Shared: JSONDecoder is stateless across decode calls and constructing one per
+    // message is measurable waste on the message path (matches the codebase's shared
+    // coder convention).
+    private static let jsonDecoder = JSONDecoder()
+
     static func parse(_ raw: String) -> BridgeParseResult {
-        // The cap is a UTF-8 *byte* budget, not a char budget.
-        // Fast path: a String's UTF-8 length is always >= its character count, so an
-        // over-length string is definitely oversized and short-circuits before the full
-        // UTF-8 walk. Precise path: exact UTF-8 wire size for the plausible range, where
-        // one character may be several bytes.
-        if raw.count > maxEnvelopeBytes || raw.utf8.count > maxEnvelopeBytes {
+        // The cap is a UTF-8 *byte* budget, not a char budget — a multi-byte payload
+        // must not sneak under the limit because it has few characters. (No char-count
+        // fast path here, unlike the Kotlin SDK: its `.length` is O(1) UTF-16 units,
+        // while Swift's `.count` walks grapheme clusters and costs more than the byte
+        // length it would short-circuit.)
+        if raw.utf8.count > maxEnvelopeBytes {
             return .invalid(.init(
                 code: .payloadTooLarge,
                 message: "envelope exceeds \(maxEnvelopeBytes) bytes"
@@ -80,7 +85,7 @@ internal enum BridgeEnvelopeParser {
 
         let rootValue: CodableValue
         do {
-            rootValue = try JSONDecoder().decode(CodableValue.self, from: Data(raw.utf8))
+            rootValue = try jsonDecoder.decode(CodableValue.self, from: Data(raw.utf8))
         } catch {
             return .invalid(.init(
                 code: .malformedJson,

--- a/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
+++ b/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
@@ -55,10 +55,10 @@ internal enum BridgeEnvelopeParser {
     /// bounds parse cost — not receive memory (the platform materializes the full String
     /// before we ever see it).
     ///
-    /// 64 KiB sits well under the cluster's single-event ingest cap (StreamingLimitBytes =
-    /// 250 KiB; ingestor/limits.go:3-14), leaving headroom for native enrichment before the
-    /// event is sent. The cluster enforces size per HTTP request body, so batch totals
-    /// (BatchLimitBytes = 500 KiB) are the dispatcher's concern, absorbed by its 413 backoff.
+    /// 64 KiB sits well under the cluster's single-event ingest cap (250 KiB —
+    /// StreamingLimitBytes in the ingestor repo), leaving headroom for native enrichment
+    /// before the event is sent. The cluster enforces size per HTTP request body, so batch
+    /// totals (BatchLimitBytes) are the dispatcher's concern, absorbed by its 413 backoff.
     static let maxEnvelopeBytes = 64 * 1024
 
     // UUIDs are 36 ASCII bytes; a generous ceiling keeps the dedup store's aggregate

--- a/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
+++ b/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+/// Error codes returned to the web producer. Closed set — the web side may branch on
+/// these, so adding a code is a contract change. The raw value is the exact string that
+/// appears in the reply payload.
+internal enum BridgeErrorCode: String, CaseIterable, Sendable {
+    case malformedJson = "malformed_json"
+    case malformedPayload = "malformed_payload"
+    case missingField = "missing_field"
+    case unknownType = "unknown_type"
+    case unsupportedVersion = "unsupported_version"
+    case payloadTooLarge = "payload_too_large"
+    case notReady = "not_ready"
+}
+
+internal enum BridgeParseResult {
+    case valid(BridgeEnvelope)
+    case invalid(Invalid)
+
+    struct Invalid: Sendable {
+        let code: BridgeErrorCode
+        let message: String
+        /// Echoed when it could be extracted — absent for unparseable input.
+        let messageId: String?
+        /// Populated only for `BridgeErrorCode.unsupportedVersion`.
+        let supportedVersion: Int?
+
+        init(
+            code: BridgeErrorCode,
+            message: String,
+            messageId: String? = nil,
+            supportedVersion: Int? = nil
+        ) {
+            self.code = code
+            self.message = message
+            self.messageId = messageId
+            self.supportedVersion = supportedVersion
+        }
+    }
+}
+
+/// Parses and validates a raw bridge message into a `BridgeEnvelope`.
+///
+/// Validation order: size limit (checked before parsing, so an oversized payload is
+/// never deserialized) → JSON well-formedness → required fields → version rule → type
+/// rule. Unknown fields are ignored so the web side can add optional fields without a
+/// version bump; optional fields with an unexpected JSON type are treated as absent
+/// rather than rejected — only `properties` (which downstream merge depends on) is
+/// strict.
+internal enum BridgeEnvelopeParser {
+
+    static let supportedVersion = 1
+
+    /// Max envelope size accepted at the untrusted JS→native boundary. A policy cap that
+    /// bounds parse cost — not receive memory (the platform materializes the full String
+    /// before we ever see it).
+    ///
+    /// 64 KiB sits well under the cluster's single-event ingest cap (StreamingLimitBytes =
+    /// 250 KiB; ingestor/limits.go:3-14), leaving headroom for native enrichment before the
+    /// event is sent. The cluster enforces size per HTTP request body, so batch totals
+    /// (BatchLimitBytes = 500 KiB) are the dispatcher's concern, absorbed by its 413 backoff.
+    static let maxEnvelopeBytes = 64 * 1024
+
+    // UUIDs are 36 chars; a generous ceiling keeps the dedup store's aggregate memory
+    // bounded in bytes, not just entry count — 1000 retained near-64KB ids would be ~64MB.
+    static let maxMessageIdChars = 256
+
+    static func parse(_ raw: String) -> BridgeParseResult {
+        // The cap is a UTF-8 *byte* budget, not a char budget.
+        // Fast path: a String's UTF-8 length is always >= its character count, so an
+        // over-length string is definitely oversized and short-circuits before the full
+        // UTF-8 walk. Precise path: exact UTF-8 wire size for the plausible range, where
+        // one character may be several bytes.
+        if raw.count > maxEnvelopeBytes || raw.utf8.count > maxEnvelopeBytes {
+            return .invalid(.init(
+                code: .payloadTooLarge,
+                message: "envelope exceeds \(maxEnvelopeBytes) bytes"
+            ))
+        }
+
+        let rootValue: CodableValue
+        do {
+            rootValue = try JSONDecoder().decode(CodableValue.self, from: Data(raw.utf8))
+        } catch {
+            return .invalid(.init(
+                code: .malformedJson,
+                message: "envelope is not valid JSON"
+            ))
+        }
+        guard case .object(let root) = rootValue else {
+            return .invalid(.init(
+                code: .malformedPayload,
+                message: "envelope must be a JSON object"
+            ))
+        }
+
+        // Extract messageId first so later rejections can echo it in the error reply.
+        guard let messageId = root["messageId"]?.stringValue,
+              !messageId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return .invalid(.init(
+                code: .missingField,
+                message: "messageId is required"
+            ))
+        }
+        if messageId.count > maxMessageIdChars {
+            // Deliberately not echoing the oversized id back — the reply would amplify
+            // the same bytes straight back to the page.
+            return .invalid(.init(
+                code: .malformedPayload,
+                message: "messageId exceeds \(maxMessageIdChars) chars"
+            ))
+        }
+
+        guard let versionValue = root["version"] else {
+            return missing("version", messageId)
+        }
+        guard case .int(let version) = versionValue else {
+            return .invalid(.init(
+                code: .malformedPayload,
+                message: "version must be an integer",
+                messageId: messageId
+            ))
+        }
+        if version < 1 {
+            return .invalid(.init(
+                code: .malformedPayload,
+                message: "version must be >= 1",
+                messageId: messageId
+            ))
+        }
+        if version > supportedVersion {
+            return .invalid(.init(
+                code: .unsupportedVersion,
+                message: "envelope version \(version) > supported \(supportedVersion)",
+                messageId: messageId,
+                supportedVersion: supportedVersion
+            ))
+        }
+
+        guard let typeString = root["type"]?.stringValue else {
+            return missing("type", messageId)
+        }
+        let type: EventType
+        switch typeString {
+        case "track": type = .track
+        case "page": type = .page
+        default:
+            return .invalid(.init(
+                code: .unknownType,
+                message: "type must be \"track\" or \"page\", got \"\(typeString)\"",
+                messageId: messageId
+            ))
+        }
+
+        guard let name = root["name"]?.stringValue,
+              !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return missing("name", messageId)
+        }
+
+        let properties: [String: CodableValue]
+        switch root["properties"] {
+        case nil:
+            properties = [:]
+        case .object(let object)?:
+            properties = object
+        default:
+            return .invalid(.init(
+                code: .malformedPayload,
+                message: "properties must be a JSON object",
+                messageId: messageId
+            ))
+        }
+
+        let page = root["page"]?.objectValue.map {
+            PageContext(
+                url: $0["url"]?.stringValue,
+                path: $0["path"]?.stringValue,
+                search: $0["search"]?.stringValue,
+                title: $0["title"]?.stringValue,
+                referrer: $0["referrer"]?.stringValue
+            )
+        }
+
+        let source = root["source"]?.objectValue.map {
+            BridgeSource(
+                producer: $0["producer"]?.stringValue,
+                wrapperVersion: $0["wrapperVersion"]?.stringValue
+            )
+        }
+
+        return .valid(BridgeEnvelope(
+            version: version,
+            messageId: messageId,
+            type: type,
+            name: name,
+            properties: properties,
+            sentAt: root["sentAt"]?.stringValue,
+            page: page,
+            source: source
+        ))
+    }
+
+    private static func missing(_ field: String, _ messageId: String?) -> BridgeParseResult {
+        return .invalid(.init(
+            code: .missingField,
+            message: "\(field) is required",
+            messageId: messageId
+        ))
+    }
+}

--- a/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
+++ b/Sources/MetaRouter/webview/BridgeEnvelopeParser.swift
@@ -61,9 +61,11 @@ internal enum BridgeEnvelopeParser {
     /// (BatchLimitBytes = 500 KiB) are the dispatcher's concern, absorbed by its 413 backoff.
     static let maxEnvelopeBytes = 64 * 1024
 
-    // UUIDs are 36 chars; a generous ceiling keeps the dedup store's aggregate memory
-    // bounded in bytes, not just entry count — 1000 retained near-64KB ids would be ~64MB.
-    static let maxMessageIdChars = 256
+    // UUIDs are 36 ASCII bytes; a generous ceiling keeps the dedup store's aggregate
+    // memory bounded in bytes, not just entry count — 1000 retained near-64KB ids would
+    // be ~64MB. Measured in UTF-8 bytes deliberately: a character count bounds nothing
+    // here, since one grapheme cluster can carry hundreds of combining marks.
+    static let maxMessageIdBytes = 256
 
     // Shared: JSONDecoder is stateless across decode calls and constructing one per
     // message is measurable waste on the message path (matches the codebase's shared
@@ -72,11 +74,14 @@ internal enum BridgeEnvelopeParser {
 
     static func parse(_ raw: String) -> BridgeParseResult {
         // The cap is a UTF-8 *byte* budget, not a char budget — a multi-byte payload
-        // must not sneak under the limit because it has few characters. (No char-count
-        // fast path here, unlike the Kotlin SDK: its `.length` is O(1) UTF-16 units,
-        // while Swift's `.count` walks grapheme clusters and costs more than the byte
-        // length it would short-circuit.)
-        if raw.utf8.count > maxEnvelopeBytes {
+        // must not sneak under the limit because it has few characters. Encoded once,
+        // measured on the result: strings off WKScriptMessage are lazily-bridged
+        // NSStrings, so a separate utf8.count would walk the string a second time.
+        // (No char-count fast path here, unlike the Kotlin SDK: its `.length` is O(1)
+        // UTF-16 units, while Swift's `.count` walks grapheme clusters and costs more
+        // than the byte length it would short-circuit.)
+        let data = Data(raw.utf8)
+        if data.count > maxEnvelopeBytes {
             return .invalid(.init(
                 code: .payloadTooLarge,
                 message: "envelope exceeds \(maxEnvelopeBytes) bytes"
@@ -85,7 +90,7 @@ internal enum BridgeEnvelopeParser {
 
         let rootValue: CodableValue
         do {
-            rootValue = try jsonDecoder.decode(CodableValue.self, from: Data(raw.utf8))
+            rootValue = try jsonDecoder.decode(CodableValue.self, from: data)
         } catch {
             return .invalid(.init(
                 code: .malformedJson,
@@ -108,12 +113,12 @@ internal enum BridgeEnvelopeParser {
                 message: "messageId is required"
             ))
         }
-        if messageId.count > maxMessageIdChars {
+        if messageId.utf8.count > maxMessageIdBytes {
             // Deliberately not echoing the oversized id back — the reply would amplify
             // the same bytes straight back to the page.
             return .invalid(.init(
                 code: .malformedPayload,
-                message: "messageId exceeds \(maxMessageIdChars) chars"
+                message: "messageId exceeds \(maxMessageIdBytes) bytes"
             ))
         }
 

--- a/Sources/MetaRouter/webview/BridgeReply.swift
+++ b/Sources/MetaRouter/webview/BridgeReply.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Ack / error reply sent back over the bridge's reply channel.
+///
+/// Serialized shape:
+/// - ok:    `{"status":"ok","messageId":"…"}`
+/// - error: `{"status":"error","messageId":"…","code":"…","message":"…","supportedVersion":1}`
+///
+/// Null fields are omitted from the wire form (e.g. `messageId` is absent when the
+/// incoming message was unparseable).
+internal struct BridgeReply: Sendable, Equatable {
+    let status: String
+    let messageId: String?
+    let code: String?
+    let message: String?
+    let supportedVersion: Int?
+
+    init(
+        status: String,
+        messageId: String? = nil,
+        code: String? = nil,
+        message: String? = nil,
+        supportedVersion: Int? = nil
+    ) {
+        self.status = status
+        self.messageId = messageId
+        self.code = code
+        self.message = message
+        self.supportedVersion = supportedVersion
+    }
+
+    /// Hand-serialized rather than JSONEncoder: the reply's field order is pinned so the
+    /// wire form is byte-identical to the other platform SDKs (JSONEncoder's key order is
+    /// unspecified), keeping page-side debugging output and contract tests stable.
+    ///
+    /// Cheap by construction, not by algorithm: every input is bounded upstream —
+    /// `messageId` ≤ 256 chars by the parser, and the one page-controlled string that
+    /// reaches `message` (the unknown-type echo) is capped by the 64 KiB envelope limit —
+    /// so the per-scalar escaping loop never sees unbounded bytes and the transient
+    /// allocations stay in the hundreds-of-bytes range. If a future contract change
+    /// echoes arbitrary payload content into replies, that bound is gone: revisit with
+    /// `reserveCapacity` and a cap at the echo site, not here.
+    func toJson() -> String {
+        var fields: [(String, String)] = [("status", Self.jsonString(status))]
+        if let messageId { fields.append(("messageId", Self.jsonString(messageId))) }
+        if let code { fields.append(("code", Self.jsonString(code))) }
+        if let message { fields.append(("message", Self.jsonString(message))) }
+        if let supportedVersion { fields.append(("supportedVersion", String(supportedVersion))) }
+        return "{" + fields.map { "\"\($0.0)\":\($0.1)" }.joined(separator: ",") + "}"
+    }
+
+    static func ok(_ messageId: String) -> BridgeReply {
+        return BridgeReply(status: "ok", messageId: messageId)
+    }
+
+    static func error(_ invalid: BridgeParseResult.Invalid) -> BridgeReply {
+        return BridgeReply(
+            status: "error",
+            messageId: invalid.messageId,
+            code: invalid.code.rawValue,
+            message: invalid.message,
+            supportedVersion: invalid.supportedVersion
+        )
+    }
+
+    static func error(
+        code: BridgeErrorCode,
+        message: String,
+        messageId: String? = nil
+    ) -> BridgeReply {
+        return BridgeReply(
+            status: "error",
+            messageId: messageId,
+            code: code.rawValue,
+            message: message
+        )
+    }
+
+    private static func jsonString(_ value: String) -> String {
+        var out = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out + "\""
+    }
+}

--- a/Sources/MetaRouter/webview/BridgeWrapperScript.swift
+++ b/Sources/MetaRouter/webview/BridgeWrapperScript.swift
@@ -22,6 +22,11 @@ import Foundation
 /// - `properties` may be an object or a JSON string (parsed by the wrapper). A string
 ///   that fails to parse is forwarded as-is so the native validator rejects it with
 ///   `malformed_payload` and the producer gets an error reply rather than silence.
+/// - JSON.stringify of the envelope is guarded: unstringifiable object properties
+///   (circular reference, BigInt) are coerced to a string and the post retried — the
+///   rest of the envelope is SDK-built strings, so the retry cannot fail, and native
+///   rejects non-object properties with malformed_payload. A coded error reply, never
+///   a TypeError thrown into the page's own calling code.
 /// - Calls made before the native channel exists (or with a blank name) are dropped.
 internal enum BridgeWrapperScript {
 
@@ -122,9 +127,15 @@ internal enum BridgeWrapperScript {
               source: { producer: 'wrapper', wrapperVersion: '\(wrapperVersion)' }
             };
             var channel = window.\(nativeChannelName);
-            if (channel && typeof channel.postMessage === 'function') {
-              channel.postMessage(JSON.stringify(envelope));
+            if (!channel || typeof channel.postMessage !== 'function') { return; }
+            var payload;
+            try {
+              payload = JSON.stringify(envelope);
+            } catch (e) {
+              envelope.properties = String(props);
+              payload = JSON.stringify(envelope);
             }
+            channel.postMessage(payload);
           }
 
           window.\(bridgeObjectName) = {

--- a/Sources/MetaRouter/webview/BridgeWrapperScript.swift
+++ b/Sources/MetaRouter/webview/BridgeWrapperScript.swift
@@ -26,7 +26,9 @@ import Foundation
 ///   (circular reference, BigInt) are coerced to a string and the post retried — the
 ///   rest of the envelope is SDK-built strings, so the retry cannot fail, and native
 ///   rejects non-object properties with malformed_payload. A coded error reply, never
-///   a TypeError thrown into the page's own calling code.
+///   a TypeError thrown into the page's own calling code. The coercion itself is
+///   guarded too: String() throws on values with no primitive path (a circular
+///   Object.create(null)), and that TypeError must stay in here as well.
 /// - Calls made before the native channel exists (or with a blank name) are dropped.
 internal enum BridgeWrapperScript {
 
@@ -132,7 +134,7 @@ internal enum BridgeWrapperScript {
             try {
               payload = JSON.stringify(envelope);
             } catch (e) {
-              envelope.properties = String(props);
+              try { envelope.properties = String(props); } catch (e2) { envelope.properties = 'unserializable'; }
               payload = JSON.stringify(envelope);
             }
             channel.postMessage(payload);

--- a/Sources/MetaRouter/webview/BridgeWrapperScript.swift
+++ b/Sources/MetaRouter/webview/BridgeWrapperScript.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Builds the JavaScript wrapper injected into attached webviews at document start.
+///
+/// The wrapper defines `window.<bridgeObjectName>` with `track`/`page` methods, wraps
+/// each call in an envelope — minting `messageId` and stamping the point-in-time page
+/// facts at call time — and posts it as a JSON string through the native channel object
+/// under `nativeChannelName`. `messageId` must be minted here, on the producer side: an
+/// ID assigned at receipt would give two deliveries of the same message two different
+/// IDs, defeating dedup.
+///
+/// On Android the platform injects the channel object (`postMessage` out, `onmessage`
+/// in); WebKit has no equivalent, so the wrapper defines the shim itself — posting via
+/// `webkit.messageHandlers` and exposing a settable `onmessage` — keeping the
+/// page-visible surface identical across platforms. Native replies are delivered by
+/// evaluating a call that fires `onmessage`.
+///
+/// - The wrapper self-checks `location.origin` against the allowlist and defines nothing
+///   on non-allowlisted pages. Unlike Android there is no platform-side origin scoping on
+///   the message handler, so this check plus the native frame-origin check carry the
+///   security model together.
+/// - `properties` may be an object or a JSON string (parsed by the wrapper). A string
+///   that fails to parse is forwarded as-is so the native validator rejects it with
+///   `malformed_payload` and the producer gets an error reply rather than silence.
+/// - Calls made before the native channel exists (or with a blank name) are dropped.
+internal enum BridgeWrapperScript {
+
+    static let defaultBridgeObjectName = "metarouterBridge"
+
+    /// Name of the `WKScriptMessageHandler` channel the wrapper posts through
+    /// (`webkit.messageHandlers.<name>.postMessage`), and of the `window` shim object
+    /// whose `onmessage` receives native replies.
+    static let nativeChannelName = "__metaRouterNativeChannel"
+
+    static let wrapperVersion = "1.0.0"
+
+    enum BuildError: Error, Equatable {
+        case emptyAllowedOrigins
+        case invalidBridgeObjectName
+    }
+
+    static func build(
+        allowedOrigins: [String],
+        bridgeObjectName: String = defaultBridgeObjectName
+    ) throws -> String {
+        guard !allowedOrigins.isEmpty else {
+            throw BuildError.emptyAllowedOrigins
+        }
+        guard bridgeObjectName.range(
+            of: "^[A-Za-z_$][A-Za-z0-9_$]*$",
+            options: .regularExpression
+        ) != nil else {
+            throw BuildError.invalidBridgeObjectName
+        }
+
+        // JSON-encoding the allowlist is what keeps a hostile origin string from breaking
+        // out of the script — quotes arrive escaped. withoutEscapingSlashes matches the
+        // other platforms' wire form so the embedded array is byte-identical.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .withoutEscapingSlashes
+        let originsData = try encoder.encode(allowedOrigins)
+        let originsJsArray = String(decoding: originsData, as: UTF8.self)
+
+        return """
+        (function() {
+          'use strict';
+          var ALLOWED_ORIGINS = \(originsJsArray);
+          if (ALLOWED_ORIGINS.indexOf(location.origin) === -1) { return; }
+          if (window.\(bridgeObjectName)) { return; }
+
+          if (!window.\(nativeChannelName)) {
+            window.\(nativeChannelName) = {
+              onmessage: null,
+              postMessage: function(data) {
+                if (window.webkit && window.webkit.messageHandlers &&
+                    window.webkit.messageHandlers.\(nativeChannelName)) {
+                  window.webkit.messageHandlers.\(nativeChannelName).postMessage(data);
+                }
+              }
+            };
+          }
+
+          function uuidv4() {
+            if (window.crypto && window.crypto.getRandomValues) {
+              var b = new Uint8Array(16);
+              window.crypto.getRandomValues(b);
+              b[6] = (b[6] & 0x0f) | 0x40;
+              b[8] = (b[8] & 0x3f) | 0x80;
+              var h = [];
+              for (var i = 0; i < 16; i++) { h.push((b[i] + 0x100).toString(16).slice(1)); }
+              return h.slice(0, 4).join('') + '-' + h.slice(4, 6).join('') + '-' +
+                     h.slice(6, 8).join('') + '-' + h.slice(8, 10).join('') + '-' +
+                     h.slice(10, 16).join('');
+            }
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+              var r = Math.random() * 16 | 0;
+              return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+            });
+          }
+
+          function post(type, name, properties) {
+            if (typeof name !== 'string' || name.length === 0) { return; }
+            var props = properties;
+            if (typeof props === 'string') {
+              try { props = JSON.parse(props); } catch (e) { /* forward as-is; native rejects */ }
+            }
+            if (props === undefined || props === null) { props = {}; }
+            var envelope = {
+              version: 1,
+              messageId: uuidv4(),
+              type: type,
+              name: name,
+              properties: props,
+              sentAt: new Date().toISOString(),
+              page: {
+                url: location.href,
+                path: location.pathname,
+                search: location.search,
+                title: document.title,
+                referrer: document.referrer
+              },
+              source: { producer: 'wrapper', wrapperVersion: '\(wrapperVersion)' }
+            };
+            var channel = window.\(nativeChannelName);
+            if (channel && typeof channel.postMessage === 'function') {
+              channel.postMessage(JSON.stringify(envelope));
+            }
+          }
+
+          window.\(bridgeObjectName) = {
+            track: function(name, properties) { post('track', name, properties); },
+            page: function(name, properties) { post('page', name, properties); }
+          };
+        })();
+        """
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeEnvelopeParserTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeEnvelopeParserTests.swift
@@ -1,0 +1,291 @@
+import XCTest
+@testable import MetaRouter
+
+final class BridgeEnvelopeParserTests: XCTestCase {
+
+    // Full envelopes exactly as the injected wrapper produces them, every field populated.
+    private let validTrack = #"{"version":1,"messageId":"9b2f2c4e-8b1a-4d7e-9c3f-2e6a1d5b8f01","type":"track","name":"product_viewed","properties":{"sku":"SKU-123","qty":2,"price":19.99},"sentAt":"2026-07-09T14:03:22.114Z","page":{"url":"https://www.metarouter.com/products","title":"Products","referrer":"https://www.metarouter.com/"},"source":{"producer":"wrapper","wrapperVersion":"1.0.0"}}"#
+
+    private let validPage = #"{"version":1,"messageId":"c41d09aa-3e02-4f4b-b0d7-77f21c9d54c2","type":"page","name":"page_view","properties":{"language":"en"},"sentAt":"2026-07-09T14:02:59.801Z","page":{"url":"https://www.metarouter.com/detail","title":"Product details","referrer":"https://www.metarouter.com/products"},"source":{"producer":"wrapper","wrapperVersion":"1.0.0"}}"#
+
+    private func valid(_ result: BridgeParseResult) -> BridgeEnvelope? {
+        guard case .valid(let envelope) = result else { return nil }
+        return envelope
+    }
+
+    private func invalid(_ result: BridgeParseResult) -> BridgeParseResult.Invalid? {
+        guard case .invalid(let invalid) = result else { return nil }
+        return invalid
+    }
+
+    // MARK: - Valid envelopes
+
+    func testValidTrackEnvelopeParsesWithAllFields() throws {
+        let envelope = try XCTUnwrap(valid(BridgeEnvelopeParser.parse(validTrack)), "expected Valid")
+
+        XCTAssertEqual(envelope.version, 1)
+        XCTAssertEqual(envelope.messageId, "9b2f2c4e-8b1a-4d7e-9c3f-2e6a1d5b8f01")
+        XCTAssertEqual(envelope.type, .track)
+        XCTAssertEqual(envelope.name, "product_viewed")
+        XCTAssertEqual(envelope.properties["sku"]?.stringValue, "SKU-123")
+        XCTAssertEqual(envelope.sentAt, "2026-07-09T14:03:22.114Z")
+        XCTAssertEqual(envelope.page?.url, "https://www.metarouter.com/products")
+        XCTAssertEqual(envelope.page?.title, "Products")
+        XCTAssertEqual(envelope.page?.referrer, "https://www.metarouter.com/")
+        XCTAssertEqual(envelope.source?.producer, "wrapper")
+        XCTAssertEqual(envelope.source?.wrapperVersion, "1.0.0")
+    }
+
+    func testValidPageEnvelopeParsesWithPageType() throws {
+        let envelope = try XCTUnwrap(valid(BridgeEnvelopeParser.parse(validPage)), "expected Valid")
+
+        XCTAssertEqual(envelope.type, .page)
+        XCTAssertEqual(envelope.name, "page_view")
+    }
+
+    func testMinimalEnvelopeWithOnlyRequiredFieldsParses() throws {
+        let envelope = try XCTUnwrap(
+            valid(BridgeEnvelopeParser.parse(#"{"version":1,"messageId":"m-1","type":"track","name":"x"}"#)),
+            "expected Valid"
+        )
+
+        XCTAssertTrue(envelope.properties.isEmpty)
+        XCTAssertNil(envelope.sentAt)
+        XCTAssertNil(envelope.page)
+        XCTAssertNil(envelope.source)
+    }
+
+    func testUnknownFieldsAreIgnoredForwardCompatibility() throws {
+        let envelope = try XCTUnwrap(
+            valid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"track","name":"x","futureField":{"a":1},"another":true}"#
+            )),
+            "expected Valid"
+        )
+
+        XCTAssertEqual(envelope.name, "x")
+    }
+
+    func testOptionalFieldsWithWrongJSONTypeAreTreatedAsAbsent() throws {
+        let envelope = try XCTUnwrap(
+            valid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"track","name":"x","page":"not-an-object","source":42,"sentAt":123}"#
+            )),
+            "expected Valid"
+        )
+
+        XCTAssertNil(envelope.page)
+        XCTAssertNil(envelope.source)
+        XCTAssertNil(envelope.sentAt)
+    }
+
+    // MARK: - Malformed input
+
+    func testInvalidJSONIsRejectedWithMalformedJsonAndNoMessageId() throws {
+        let error = try XCTUnwrap(invalid(BridgeEnvelopeParser.parse("{not json")), "expected Invalid")
+
+        XCTAssertEqual(error.code, .malformedJson)
+        XCTAssertNil(error.messageId)
+    }
+
+    func testNonObjectJSONIsRejectedWithMalformedPayload() throws {
+        let error = try XCTUnwrap(invalid(BridgeEnvelopeParser.parse(#"["an","array"]"#)), "expected Invalid")
+
+        XCTAssertEqual(error.code, .malformedPayload)
+    }
+
+    func testNonObjectPropertiesIsRejectedWithMalformedPayloadAndEchoesMessageId() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"track","name":"x","properties":"oops"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .malformedPayload)
+        XCTAssertEqual(error.messageId, "m-1")
+    }
+
+    func testNonIntegerVersionIsRejectedWithMalformedPayload() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":"one","messageId":"m-1","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .malformedPayload)
+    }
+
+    func testVersionBelowOneIsRejectedWithMalformedPayload() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":0,"messageId":"m-1","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .malformedPayload)
+    }
+
+    // MARK: - Partial input (missing required fields)
+
+    func testMissingMessageIdIsRejectedWithMissingField() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(#"{"version":1,"type":"track","name":"x"}"#)),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+    }
+
+    func testOversizedMessageIdIsRejectedWithoutEchoingItBack() throws {
+        let hugeId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdChars + 1)
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"\#(hugeId)","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .malformedPayload)
+        // The reply must not amplify the oversized bytes back to the page.
+        XCTAssertNil(error.messageId)
+        XCTAssertFalse(error.message.contains(hugeId))
+    }
+
+    func testMessageIdAtExactlyTheCapIsAccepted() throws {
+        let maxId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdChars)
+        let envelope = try XCTUnwrap(
+            valid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"\#(maxId)","type":"track","name":"x"}"#
+            )),
+            "expected Valid"
+        )
+
+        XCTAssertEqual(envelope.messageId, maxId)
+    }
+
+    func testPagePathAndSearchAreParsed() throws {
+        let envelope = try XCTUnwrap(
+            valid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"page","name":"page_view","page":{"url":"https://www.metarouter.com/products?q=fern","path":"/products","search":"?q=fern"}}"#
+            )),
+            "expected Valid"
+        )
+
+        XCTAssertEqual(envelope.page?.path, "/products")
+        XCTAssertEqual(envelope.page?.search, "?q=fern")
+    }
+
+    func testBlankMessageIdIsRejectedWithMissingField() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"  ","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+    }
+
+    func testMissingVersionIsRejectedWithMissingFieldAndEchoesMessageId() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(#"{"messageId":"m-1","type":"track","name":"x"}"#)),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+        XCTAssertEqual(error.messageId, "m-1")
+    }
+
+    func testMissingTypeIsRejectedWithMissingField() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(#"{"version":1,"messageId":"m-1","name":"x"}"#)),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+    }
+
+    func testMissingNameIsRejectedWithMissingField() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(#"{"version":1,"messageId":"m-1","type":"track"}"#)),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+    }
+
+    func testEmptyNameIsRejectedWithMissingField() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"track","name":""}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .missingField)
+    }
+
+    // MARK: - Type rule
+
+    func testUnknownTypeIsRejectedWithUnknownType() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"identify","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .unknownType)
+        XCTAssertEqual(error.messageId, "m-1")
+    }
+
+    func testScreenTypeIsRejectedInContractV1() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"m-1","type":"screen","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .unknownType)
+    }
+
+    // MARK: - Version rule
+
+    func testNewerVersionIsRejectedWithUnsupportedVersionAndSupportedVersion() throws {
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":2,"messageId":"m-1","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .unsupportedVersion)
+        XCTAssertEqual(error.messageId, "m-1")
+        XCTAssertEqual(error.supportedVersion, BridgeEnvelopeParser.supportedVersion)
+    }
+
+    // MARK: - Oversized input
+
+    func testEnvelopeOver64KBIsRejectedWithPayloadTooLarge() throws {
+        let padding = String(repeating: "a", count: BridgeEnvelopeParser.maxEnvelopeBytes)
+        let oversized = #"{"version":1,"messageId":"m-1","type":"track","name":"x","properties":{"p":"\#(padding)"}}"#
+
+        let error = try XCTUnwrap(invalid(BridgeEnvelopeParser.parse(oversized)), "expected Invalid")
+
+        XCTAssertEqual(error.code, .payloadTooLarge)
+    }
+
+    func testSizeLimitIsMeasuredInUTF8BytesNotChars() throws {
+        // Multi-byte characters: 22000 × 3-byte chars ≈ 66KB > 64KB limit, but only 22k chars.
+        let padding = String(repeating: "€", count: 22_000)
+        let oversized = #"{"version":1,"messageId":"m-1","type":"track","name":"x","properties":{"p":"\#(padding)"}}"#
+
+        let error = try XCTUnwrap(invalid(BridgeEnvelopeParser.parse(oversized)), "expected Invalid")
+
+        XCTAssertEqual(error.code, .payloadTooLarge)
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeEnvelopeParserTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeEnvelopeParserTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class BridgeEnvelopeParserTests: XCTestCase {
 
     // Full envelopes exactly as the injected wrapper produces them, every field populated.
-    private let validTrack = #"{"version":1,"messageId":"9b2f2c4e-8b1a-4d7e-9c3f-2e6a1d5b8f01","type":"track","name":"product_viewed","properties":{"sku":"SKU-123","qty":2,"price":19.99},"sentAt":"2026-07-09T14:03:22.114Z","page":{"url":"https://www.metarouter.com/products","title":"Products","referrer":"https://www.metarouter.com/"},"source":{"producer":"wrapper","wrapperVersion":"1.0.0"}}"#
+    private let validTrack = #"{"version":1,"messageId":"9b2f2c4e-8b1a-4d7e-9c3f-2e6a1d5b8f01","type":"track","name":"product_viewed","properties":{"sku":"SKU-123","qty":2,"price":19.99,"flag":true},"sentAt":"2026-07-09T14:03:22.114Z","page":{"url":"https://www.metarouter.com/products","title":"Products","referrer":"https://www.metarouter.com/"},"source":{"producer":"wrapper","wrapperVersion":"1.0.0"}}"#
 
     private let validPage = #"{"version":1,"messageId":"c41d09aa-3e02-4f4b-b0d7-77f21c9d54c2","type":"page","name":"page_view","properties":{"language":"en"},"sentAt":"2026-07-09T14:02:59.801Z","page":{"url":"https://www.metarouter.com/detail","title":"Product details","referrer":"https://www.metarouter.com/products"},"source":{"producer":"wrapper","wrapperVersion":"1.0.0"}}"#
 
@@ -28,6 +28,9 @@ final class BridgeEnvelopeParserTests: XCTestCase {
         XCTAssertEqual(envelope.type, .track)
         XCTAssertEqual(envelope.name, "product_viewed")
         XCTAssertEqual(envelope.properties["sku"]?.stringValue, "SKU-123")
+        // Bools stay bools — the JSONDecoder-over-JSONSerialization choice exists for
+        // this line (NSNumber bridging would silently turn true into 1).
+        XCTAssertEqual(envelope.properties["flag"]?.boolValue, true)
         XCTAssertEqual(envelope.sentAt, "2026-07-09T14:03:22.114Z")
         XCTAssertEqual(envelope.page?.url, "https://www.metarouter.com/products")
         XCTAssertEqual(envelope.page?.title, "Products")
@@ -140,7 +143,7 @@ final class BridgeEnvelopeParserTests: XCTestCase {
     }
 
     func testOversizedMessageIdIsRejectedWithoutEchoingItBack() throws {
-        let hugeId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdChars + 1)
+        let hugeId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdBytes + 1)
         let error = try XCTUnwrap(
             invalid(BridgeEnvelopeParser.parse(
                 #"{"version":1,"messageId":"\#(hugeId)","type":"track","name":"x"}"#
@@ -155,7 +158,7 @@ final class BridgeEnvelopeParserTests: XCTestCase {
     }
 
     func testMessageIdAtExactlyTheCapIsAccepted() throws {
-        let maxId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdChars)
+        let maxId = String(repeating: "x", count: BridgeEnvelopeParser.maxMessageIdBytes)
         let envelope = try XCTUnwrap(
             valid(BridgeEnvelopeParser.parse(
                 #"{"version":1,"messageId":"\#(maxId)","type":"track","name":"x"}"#
@@ -164,6 +167,24 @@ final class BridgeEnvelopeParserTests: XCTestCase {
         )
 
         XCTAssertEqual(envelope.messageId, maxId)
+    }
+
+    func testMessageIdCapIsMeasuredInBytesNotCharacters() throws {
+        // 100 characters of 3-byte "€" = 300 UTF-8 bytes: under the cap by character
+        // count, over it by bytes. A character count bounds nothing — one grapheme
+        // cluster can carry hundreds of combining marks — and the dedup store's memory
+        // ceiling depends on the byte bound being real.
+        let id = String(repeating: "€", count: 100)
+        let error = try XCTUnwrap(
+            invalid(BridgeEnvelopeParser.parse(
+                #"{"version":1,"messageId":"\#(id)","type":"track","name":"x"}"#
+            )),
+            "expected Invalid"
+        )
+
+        XCTAssertEqual(error.code, .malformedPayload)
+        XCTAssertNil(error.messageId)
+        XCTAssertFalse(error.message.contains(id))
     }
 
     func testPagePathAndSearchAreParsed() throws {

--- a/Tests/MetaRouterTests/webview/BridgeReplyTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeReplyTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import MetaRouter
+
+final class BridgeReplyTests: XCTestCase {
+
+    func testOkReplySerializesToContractShape() {
+        let json = BridgeReply.ok("m-1").toJson()
+
+        XCTAssertEqual(json, #"{"status":"ok","messageId":"m-1"}"#)
+    }
+
+    func testErrorReplyFromInvalidCarriesCodeMessageAndSupportedVersion() {
+        let invalid = BridgeParseResult.Invalid(
+            code: .unsupportedVersion,
+            message: "envelope version 2 > supported 1",
+            messageId: "m-1",
+            supportedVersion: 1
+        )
+
+        let json = BridgeReply.error(invalid).toJson()
+
+        XCTAssertEqual(
+            json,
+            #"{"status":"error","messageId":"m-1","code":"unsupported_version","message":"envelope version 2 > supported 1","supportedVersion":1}"#
+        )
+    }
+
+    func testErrorReplyOmitsNullFields() {
+        let invalid = BridgeParseResult.Invalid(
+            code: .malformedJson,
+            message: "envelope is not valid JSON"
+        )
+
+        let json = BridgeReply.error(invalid).toJson()
+
+        XCTAssertFalse(json.contains("messageId"), "messageId should be omitted")
+        XCTAssertFalse(json.contains("supportedVersion"), "supportedVersion should be omitted")
+        XCTAssertTrue(json.contains(#""code":"malformed_json""#))
+    }
+
+    func testStandaloneErrorFactoryUsesWireCodeStrings() {
+        let json = BridgeReply.error(code: .notReady, message: "SDK not initialized").toJson()
+
+        XCTAssertTrue(json.contains(#""code":"not_ready""#))
+        XCTAssertTrue(json.contains(#"status":"error"#))
+    }
+
+    func testEveryErrorCodeHasAStableWireString() {
+        let expected: [BridgeErrorCode: String] = [
+            .malformedJson: "malformed_json",
+            .malformedPayload: "malformed_payload",
+            .missingField: "missing_field",
+            .unknownType: "unknown_type",
+            .unsupportedVersion: "unsupported_version",
+            .payloadTooLarge: "payload_too_large",
+            .notReady: "not_ready",
+        ]
+
+        XCTAssertEqual(expected.count, BridgeErrorCode.allCases.count)
+        for (code, wire) in expected {
+            XCTAssertEqual(code.rawValue, wire)
+        }
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
@@ -35,9 +35,11 @@ final class BridgeWrapperScriptTests: XCTestCase {
         let script = try BridgeWrapperScript.build(allowedOrigins: origins)
 
         // A circular reference or BigInt in object properties would otherwise throw a
-        // TypeError out of track()/page() into the page's own calling code.
+        // TypeError out of track()/page() into the page's own calling code — and so
+        // would the String() coercion itself on a value with no primitive path (a
+        // circular Object.create(null)), hence the inner guard.
         XCTAssertTrue(script.contains("payload = JSON.stringify(envelope);"))
-        XCTAssertTrue(script.contains("envelope.properties = String(props);"))
+        XCTAssertTrue(script.contains("try { envelope.properties = String(props); } catch (e2) { envelope.properties = 'unserializable'; }"))
         XCTAssertFalse(script.contains("channel.postMessage(JSON.stringify(envelope))"))
     }
 

--- a/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
@@ -28,7 +28,32 @@ final class BridgeWrapperScriptTests: XCTestCase {
         let script = try BridgeWrapperScript.build(allowedOrigins: origins)
 
         XCTAssertTrue(script.contains("window.\(BridgeWrapperScript.nativeChannelName)"))
-        XCTAssertTrue(script.contains("channel.postMessage(JSON.stringify(envelope))"))
+        XCTAssertTrue(script.contains("channel.postMessage(payload)"))
+    }
+
+    func testStringifyIsGuardedAndCoercesUnserializableProperties() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        // A circular reference or BigInt in object properties would otherwise throw a
+        // TypeError out of track()/page() into the page's own calling code.
+        XCTAssertTrue(script.contains("payload = JSON.stringify(envelope);"))
+        XCTAssertTrue(script.contains("envelope.properties = String(props);"))
+        XCTAssertFalse(script.contains("channel.postMessage(JSON.stringify(envelope))"))
+    }
+
+    func testCoercedStringPropertiesAreRejectedByTheParserAsMalformedPayload() throws {
+        // The wrapper's stringify fallback sends properties as a coerced string; this
+        // pins the native half of that contract — a coded error reply, id echoed.
+        let result = BridgeEnvelopeParser.parse(
+            #"{"version":1,"messageId":"m-1","type":"track","name":"x","properties":"[object Object]"}"#
+        )
+
+        guard case .invalid(let invalid) = result else {
+            XCTFail("expected Invalid, got \(result)")
+            return
+        }
+        XCTAssertEqual(invalid.code, .malformedPayload)
+        XCTAssertEqual(invalid.messageId, "m-1")
     }
 
     /// The one transport line that differs from Android: the shim posts through

--- a/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeWrapperScriptTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import MetaRouter
+
+final class BridgeWrapperScriptTests: XCTestCase {
+
+    private let origins = ["https://www.metarouter.com"]
+
+    func testScriptDefinesTheDefaultBridgeObjectWithTrackAndPage() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(script.contains("window.metarouterBridge = {"))
+        XCTAssertTrue(script.contains("track: function(name, properties)"))
+        XCTAssertTrue(script.contains("page: function(name, properties)"))
+    }
+
+    func testScriptEmbedsTheOriginAllowlistAsAJSONArray() throws {
+        let script = try BridgeWrapperScript.build(
+            allowedOrigins: ["https://www.metarouter.com", "https://booking.metarouter.com"]
+        )
+
+        XCTAssertTrue(
+            script.contains(#"var ALLOWED_ORIGINS = ["https://www.metarouter.com","https://booking.metarouter.com"];"#)
+        )
+        XCTAssertTrue(script.contains("ALLOWED_ORIGINS.indexOf(location.origin) === -1"))
+    }
+
+    func testScriptPostsThroughTheNativeChannelObject() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(script.contains("window.\(BridgeWrapperScript.nativeChannelName)"))
+        XCTAssertTrue(script.contains("channel.postMessage(JSON.stringify(envelope))"))
+    }
+
+    /// The one transport line that differs from Android: the shim posts through
+    /// `webkit.messageHandlers` instead of a platform-injected channel object.
+    func testScriptShimPostsThroughWebkitMessageHandlers() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(
+            script.contains("window.webkit.messageHandlers.\(BridgeWrapperScript.nativeChannelName).postMessage(data)")
+        )
+        XCTAssertTrue(script.contains("onmessage: null"))
+    }
+
+    func testScriptStampsTheFullPageBlockIncludingPathAndSearch() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(script.contains("url: location.href"))
+        XCTAssertTrue(script.contains("path: location.pathname"))
+        XCTAssertTrue(script.contains("search: location.search"))
+        XCTAssertTrue(script.contains("title: document.title"))
+        XCTAssertTrue(script.contains("referrer: document.referrer"))
+    }
+
+    func testScriptStampsEnvelopeVersionAndWrapperVersion() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(script.contains("version: 1,"))
+        XCTAssertTrue(script.contains("wrapperVersion: '\(BridgeWrapperScript.wrapperVersion)'"))
+    }
+
+    func testScriptGuardsAgainstDoubleDefinition() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins)
+
+        XCTAssertTrue(script.contains("if (window.metarouterBridge) { return; }"))
+    }
+
+    func testCustomBridgeObjectNameIsHonoredEverywhere() throws {
+        let script = try BridgeWrapperScript.build(allowedOrigins: origins, bridgeObjectName: "customBridge")
+
+        XCTAssertTrue(script.contains("window.customBridge = {"))
+        XCTAssertTrue(script.contains("if (window.customBridge) { return; }"))
+        XCTAssertFalse(script.contains("metarouterBridge"))
+    }
+
+    func testOriginsContainingQuotesAreEscapedSafely() throws {
+        // A hostile origin string must not be able to break out of the JS string literal:
+        // the embedded quote must appear escaped (\"), never as a bare closing quote.
+        let script = try BridgeWrapperScript.build(allowedOrigins: [#"https://x.com/"};alert(1);//"#])
+
+        XCTAssertTrue(script.contains(#"/\"};alert(1);//"#), "quote must be escaped")
+        XCTAssertFalse(script.contains(#"/"};alert(1);//"#), "bare quote would terminate the JS string")
+    }
+
+    func testEmptyOriginListIsRejected() {
+        XCTAssertThrowsError(try BridgeWrapperScript.build(allowedOrigins: [])) { error in
+            XCTAssertEqual(error as? BridgeWrapperScript.BuildError, .emptyAllowedOrigins)
+        }
+    }
+
+    func testInvalidJSIdentifierForBridgeObjectNameIsRejected() {
+        XCTAssertThrowsError(
+            try BridgeWrapperScript.build(allowedOrigins: origins, bridgeObjectName: "bad-name;alert(1)")
+        ) { error in
+            XCTAssertEqual(error as? BridgeWrapperScript.BuildError, .invalidBridgeObjectName)
+        }
+    }
+
+    func testWrapperEnvelopeRoundTripsThroughTheNativeParser() throws {
+        // Build the envelope shape the wrapper's post() constructs and confirm the
+        // native parser accepts it — keeps script and parser from drifting apart.
+        let envelope = #"""
+        {"version":1,"messageId":"11111111-2222-4333-8444-555555555555","type":"track",
+         "name":"product_viewed","properties":{"sku":"SKU-1"},
+         "sentAt":"2026-07-09T14:03:22.114Z",
+         "page":{"url":"https://www.metarouter.com/products","title":"Search","referrer":""},
+         "source":{"producer":"wrapper","wrapperVersion":"\#(BridgeWrapperScript.wrapperVersion)"}}
+        """#
+
+        let result = BridgeEnvelopeParser.parse(envelope)
+
+        guard case .valid(let parsed) = result else {
+            XCTFail("wrapper-shaped envelope must parse, got \(result)")
+            return
+        }
+        XCTAssertEqual(parsed.source?.wrapperVersion, BridgeWrapperScript.wrapperVersion)
+    }
+}


### PR DESCRIPTION
**Shortcut:** [sc-39686](https://app.shortcut.com/metarouter/story/39686) (envelope contract) · [sc-39688](https://app.shortcut.com/metarouter/story/39688) (receiver validation)
**Epic:** [39685 — WebView → Native Event Proxy Bridge](https://app.shortcut.com/metarouter/epic/39685)
**Android reference:** metarouterio/android-sdk#35 — ported 1:1; divergences listed below.
**Slice 1 of 4** — pure additions; nothing references the new module yet.

## Summary

The envelope layer of the webview bridge: the contract types, the validator, and the JS wrapper the SDK injects into attached webviews.

- `BridgeEnvelope` — validated envelope model, only produced by the parser, so downstream code (merge, dedup) never re-validates. `version`/`sentAt`/`source` are contract fields carried but not yet consumed (rationale on the type).
- `BridgeEnvelopeParser` — size limit checked **before** parsing (oversized payloads are never deserialized) with the char-count short-circuit, required fields, version rule (accept ≤ supported; reject newer with `supportedVersion` echoed), type rule (`track`/`page`; `screen` reserved). Unknown fields ignored for forward compatibility.
- `BridgeReply` — ack/error wire shape, closed error-code set, null fields omitted.
- `BridgeWrapperScript` — document-start wrapper defining `window.metarouterBridge.track/page`. `messageId` minted producer-side (a receipt-side ID cannot detect redelivery); origin self-check; origins JSON-escaped so a hostile string cannot break out of the script. Properties accepted as object or JSON string.
- `types.PageContext` lands here (type only, no context field yet) so the envelope layer stands alone.

## Swift adaptations (vs the Kotlin reference)

- **Envelope properties are `[String: CodableValue]`** (vs `Map<String, JsonElement>`), decoded via `JSONDecoder` into the repo's existing `CodableValue` — deliberately not `JSONSerialization` + `CodableValue.from`, which corrupts JSON booleans into ints through NSNumber bridging.
- **`BridgeReply.toJson()` is hand-serialized with pinned field order** — `JSONEncoder`'s key order is unspecified, and byte parity with the Android wire form keeps the pinned-string contract tests portable and page-side debugging output identical across platforms. Bounded-input rationale documented on the method.
- **`BridgeWrapperScript.build` throws** (`BuildError`) — the Swift equivalent of Kotlin's `require` → `IllegalArgumentException`; keeps the two rejection tests portable. Slice 3 validates origins before this can ever throw.
- **The channel shim is the one real divergence**: Android's platform injects `__metaRouterNativeChannel`; WebKit doesn't, so the wrapper defines it itself — `postMessage` routes to `webkit.messageHandlers`, `onmessage` is settable for reply parity. One extra wrapper test pins it.
- Micro-divergence, deliberate: kotlinx's `intOrNull` accepts `"version":"1"` (numeric string); iOS rejects it as `malformed_payload`. The contract says integer; the lenient case is untested on Android and looks like an implementation artifact rather than intent.

## Stack

1. **this PR** — envelope + validation + wrapper foundation
2. sc-39691 — dedup store + message processor
3. sc-40572 — proxy-owned wiring + `attachWebView` public API
4. sc-40573 — README documentation

## Test plan

- [x] Parser: valid/malformed/partial/oversized (incl. UTF-8-bytes-vs-chars), version + type rules, forward-compat — Android's suite ported 1:1
- [x] Replies match the contract byte-for-byte; every error code's wire string pinned
- [x] Wrapper: surface, origin allowlist embedding, hostile-origin escaping, webkit.messageHandlers shim, wrapper↔parser round-trip
- [x] `swift test` passes (only pre-existing `AnalyticsProxyTests` ordering flake, reproduced on clean `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)