### PR TITLE
feat: webview bridge dedup store + message processor [2/4]

### DIFF
--- a/Sources/MetaRouter/webview/BridgeDedupStore.swift
+++ b/Sources/MetaRouter/webview/BridgeDedupStore.swift
@@ -16,14 +16,20 @@ internal final class BridgeDedupStore: @unchecked Sendable {
     static let defaultMaxEntries = 1_000
     static let defaultTtlMillis: Int64 = 5 * 60 * 1000
 
+    // The tick→nanosecond scaling factors are process-constant; fetch once, not on
+    // every clock read on the message path.
+    private static let timebase: mach_timebase_info_data_t = {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return info
+    }()
+
     /// Monotonic: immune to wall-clock jumps (NTP, user time changes), and — unlike
     /// `ProcessInfo.systemUptime` or `mach_absolute_time`, which pause in deep sleep —
     /// `mach_continuous_time` is documented to keep incrementing while the device is
     /// asleep, so the window measures real elapsed time, which is what a redelivery
     /// window means.
     static func continuousClockMillis() -> Int64 {
-        var timebase = mach_timebase_info_data_t()
-        mach_timebase_info(&timebase)
         let nanos = mach_continuous_time() * UInt64(timebase.numer) / UInt64(timebase.denom)
         return Int64(nanos / 1_000_000)
     }

--- a/Sources/MetaRouter/webview/BridgeDedupStore.swift
+++ b/Sources/MetaRouter/webview/BridgeDedupStore.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Bounded record of recently seen bridge `messageId`s.
+///
+/// Redelivery happens when the page re-posts after a lost ack, so a duplicate can only
+/// arrive within a short window of the original — entries older than `ttlMillis` can be
+/// treated as never-seen. The size bound exists because a long-lived webview session
+/// would otherwise grow the store for its whole lifetime; when full, the oldest entry is
+/// evicted first since it is also the one least likely to still be inside any redelivery
+/// window.
+///
+/// In-memory only: a duplicate delivered across a process restart is indistinguishable
+/// from a fresh event and rare enough not to justify disk I/O on the message path.
+internal final class BridgeDedupStore: @unchecked Sendable {
+
+    static let defaultMaxEntries = 1_000
+    static let defaultTtlMillis: Int64 = 5 * 60 * 1000
+
+    /// Monotonic: immune to wall-clock jumps (NTP, user time changes), and — unlike
+    /// `ProcessInfo.systemUptime` or `mach_absolute_time`, which pause in deep sleep —
+    /// `mach_continuous_time` is documented to keep incrementing while the device is
+    /// asleep, so the window measures real elapsed time, which is what a redelivery
+    /// window means.
+    static func continuousClockMillis() -> Int64 {
+        var timebase = mach_timebase_info_data_t()
+        mach_timebase_info(&timebase)
+        let nanos = mach_continuous_time() * UInt64(timebase.numer) / UInt64(timebase.denom)
+        return Int64(nanos / 1_000_000)
+    }
+
+    private let maxEntries: Int
+    private let ttlMillis: Int64
+    /// Must be safe to call from any thread — the default is; test clocks run
+    /// single-threaded.
+    private let clock: () -> Int64
+
+    // Insertion-ordered bookkeeping so eviction removes the oldest messageId. The array
+    // stays at most maxEntries long, so the O(n) removals are bounded and cheap. Guarded
+    // by the lock: messages arrive on the WebView's thread while the SDK may probe from
+    // background workers.
+    private let lock = NSLock()
+    private var seen: [String: Int64] = [:]
+    private var insertionOrder: [String] = []
+
+    init(
+        maxEntries: Int = BridgeDedupStore.defaultMaxEntries,
+        ttlMillis: Int64 = BridgeDedupStore.defaultTtlMillis,
+        clock: @escaping () -> Int64 = BridgeDedupStore.continuousClockMillis
+    ) {
+        precondition(maxEntries > 0, "maxEntries must be > 0")
+        precondition(ttlMillis > 0, "ttlMillis must be > 0")
+        self.maxEntries = maxEntries
+        self.ttlMillis = ttlMillis
+        self.clock = clock
+    }
+
+    /// Records `messageId` and reports whether it was new.
+    ///
+    /// - Returns: `true` if unseen (or seen only outside the TTL window) — caller should
+    ///   process the message; `false` for a live duplicate — caller should drop it.
+    ///   A duplicate does NOT refresh the original timestamp: refreshing would let a
+    ///   producer stuck in a re-post loop keep its entry alive forever.
+    func markIfNew(_ messageId: String) -> Bool {
+        let now = clock()
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let firstSeenAt = seen[messageId], now - firstSeenAt < ttlMillis {
+            return false
+        }
+        // Remove before re-insert so an expired entry moves to the back of the
+        // eviction order instead of keeping its stale position.
+        if seen.removeValue(forKey: messageId) != nil {
+            insertionOrder.removeAll { $0 == messageId }
+        }
+        seen[messageId] = now
+        insertionOrder.append(messageId)
+        if seen.count > maxEntries {
+            let eldest = insertionOrder.removeFirst()
+            seen.removeValue(forKey: eldest)
+        }
+        return true
+    }
+
+    /// Removes a recorded id. Used when the message it marked never entered the
+    /// delivery path — leaving it recorded would make a legitimate producer retry
+    /// read as a duplicate of an event that was actually lost.
+    func forget(_ messageId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if seen.removeValue(forKey: messageId) != nil {
+            insertionOrder.removeAll { $0 == messageId }
+        }
+    }
+
+    func size() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return seen.count
+    }
+}

--- a/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
+++ b/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
@@ -34,8 +34,12 @@ internal final class BridgeMessageProcessor {
     func process(_ raw: String) -> BridgeReply {
         switch BridgeEnvelopeParser.parse(raw) {
         case .invalid(let invalid):
+            // The reply must stay complete — that is the contract — but the log need
+            // not: for unknown_type the message embeds page-controlled text bounded
+            // only by the envelope cap, and a hostile page should not get to write
+            // 64KB lines into a customer's device log.
             Logger.warn(
-                "WebView bridge message rejected (\(invalid.code.rawValue)): \(invalid.message)"
+                "WebView bridge message rejected (\(invalid.code.rawValue)): \(String(invalid.message.prefix(200)))"
             )
             return BridgeReply.error(invalid)
 

--- a/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
+++ b/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Receives validated, deduplicated envelopes for merge + enqueue. Implemented by the
+/// client wiring; kept as a single-method seam so the processing pipeline is testable
+/// without a real SDK instance.
+///
+/// Returns whether the event actually entered the delivery path — an `ok` ack for an
+/// event that was silently dropped (SDK resetting, channel full) would lie to the
+/// producer, so the reply must reflect this result.
+internal protocol BridgeEventSink {
+    func enqueue(_ envelope: BridgeEnvelope) -> Bool
+}
+
+/// The receive pipeline for one attached webview: raw message → parse/validate → dedup →
+/// sink, producing the reply to send back to the wrapper.
+///
+/// Rejections are logged natively as well as replied — page JS consoles are rarely
+/// watched in production, so the native log is the primary debugging surface for a
+/// misbehaving integration.
+internal final class BridgeMessageProcessor {
+
+    private let sink: BridgeEventSink
+    private let dedupStore: BridgeDedupStore
+
+    init(sink: BridgeEventSink, dedupStore: BridgeDedupStore = BridgeDedupStore()) {
+        self.sink = sink
+        self.dedupStore = dedupStore
+    }
+
+    /// Synchronous; the caller chooses the thread. NOT safe to call concurrently for the
+    /// same processor — `markIfNew → enqueue → forget` is a check-then-act across two lock
+    /// regions, so a concurrent duplicate could be acked `ok` and dropped while the
+    /// original's enqueue fails, losing the event. Invoke from a single confined thread.
+    func process(_ raw: String) -> BridgeReply {
+        switch BridgeEnvelopeParser.parse(raw) {
+        case .invalid(let invalid):
+            Logger.warn(
+                "WebView bridge message rejected (\(invalid.code.rawValue)): \(invalid.message)"
+            )
+            return BridgeReply.error(invalid)
+
+        case .valid(let envelope):
+            if !dedupStore.markIfNew(envelope.messageId) {
+                // Duplicates are acked ok, not errored: the producer's goal —
+                // exactly-once enqueue — was already met by the first delivery.
+                Logger.log(
+                    "WebView bridge duplicate dropped (messageId=\(envelope.messageId))"
+                )
+                return BridgeReply.ok(envelope.messageId)
+            }
+            if sink.enqueue(envelope) {
+                return BridgeReply.ok(envelope.messageId)
+            }
+            // The event never entered the delivery path — un-record the id so
+            // a producer retry is not misread as a duplicate of a message that
+            // was in fact lost.
+            dedupStore.forget(envelope.messageId)
+            Logger.warn(
+                "WebView bridge event not accepted (messageId=\(envelope.messageId))"
+            )
+            return BridgeReply.error(
+                code: .notReady,
+                message: "SDK not ready to accept events",
+                messageId: envelope.messageId
+            )
+        }
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeDedupStoreTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeDedupStoreTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import MetaRouter
+
+final class BridgeDedupStoreTests: XCTestCase {
+
+    private var now: Int64 = 1_000_000
+
+    private func makeStore(
+        maxEntries: Int = BridgeDedupStore.defaultMaxEntries,
+        ttlMillis: Int64 = BridgeDedupStore.defaultTtlMillis
+    ) -> BridgeDedupStore {
+        BridgeDedupStore(maxEntries: maxEntries, ttlMillis: ttlMillis) { self.now }
+    }
+
+    func testFirstSightingIsNew() {
+        XCTAssertTrue(makeStore().markIfNew("m-1"))
+    }
+
+    func testSecondSightingWithinTtlIsADuplicate() {
+        let store = makeStore()
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        XCTAssertFalse(store.markIfNew("m-1"))
+    }
+
+    func testDistinctIdsDoNotCollide() {
+        let store = makeStore()
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        XCTAssertTrue(store.markIfNew("m-2"))
+        XCTAssertFalse(store.markIfNew("m-1"))
+        XCTAssertFalse(store.markIfNew("m-2"))
+    }
+
+    func testSightingAfterTtlExpiryIsNewAgain() {
+        let store = makeStore(ttlMillis: 1_000)
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        now += 1_001
+        XCTAssertTrue(store.markIfNew("m-1"))
+    }
+
+    func testSightingAtExactlyTheTtlBoundaryCountsAsExpired() {
+        // The window check is strict (<): elapsed == ttl is outside the window. A
+        // flipped comparison would silently change this; one assertion pins it.
+        let store = makeStore(ttlMillis: 1_000)
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        now += 1_000
+        XCTAssertTrue(store.markIfNew("m-1"))
+    }
+
+    func testDuplicateDoesNotRefreshTheTtlWindow() {
+        let store = makeStore(ttlMillis: 1_000)
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        now += 600
+        XCTAssertFalse(store.markIfNew("m-1"))
+        // 1_100ms after FIRST sighting: if the duplicate at 600ms had refreshed the
+        // timestamp, this would still be inside the window and report a duplicate.
+        now += 500
+        XCTAssertTrue(store.markIfNew("m-1"))
+    }
+
+    func testOldestEntryIsEvictedWhenTheStoreIsFull() {
+        let store = makeStore(maxEntries: 3)
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        XCTAssertTrue(store.markIfNew("m-2"))
+        XCTAssertTrue(store.markIfNew("m-3"))
+        XCTAssertTrue(store.markIfNew("m-4"))
+
+        XCTAssertEqual(store.size(), 3)
+        // m-1 was evicted, so it reads as new; m-4 is still live.
+        XCTAssertTrue(store.markIfNew("m-1"))
+        XCTAssertFalse(store.markIfNew("m-4"))
+    }
+
+    func testSizeNeverExceedsTheBound() {
+        let store = makeStore(maxEntries: 10)
+
+        for i in 0..<100 {
+            XCTAssertTrue(store.markIfNew("m-\(i)"))
+        }
+
+        XCTAssertEqual(store.size(), 10)
+    }
+
+    func testExpiredEntryReSightingMovesItToTheBackOfTheEvictionOrder() {
+        let store = makeStore(maxEntries: 2, ttlMillis: 1_000)
+
+        XCTAssertTrue(store.markIfNew("m-1"))
+        now += 1_001
+        XCTAssertTrue(store.markIfNew("m-1")) // expired → re-recorded at `now`
+        XCTAssertTrue(store.markIfNew("m-2"))
+        XCTAssertTrue(store.markIfNew("m-3")) // store full — evicts the eldest entry
+
+        // m-1 was re-recorded before m-2, so m-1 is the eviction victim; m-2 survives.
+        // If the expired re-sighting had kept m-1's original slot position, m-2 would
+        // have been evicted here instead.
+        XCTAssertFalse(store.markIfNew("m-2"))
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeDedupStoreTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeDedupStoreTests.swift
@@ -86,6 +86,29 @@ final class BridgeDedupStoreTests: XCTestCase {
         XCTAssertEqual(store.size(), 10)
     }
 
+    func testConcurrentMarkForgetAndSizeKeepTheStoreCoherent() {
+        // The lock exists because messages arrive on the WebView's thread while the
+        // SDK may probe from background workers — every other test here is
+        // single-threaded, so this is the one that actually exercises it (and gives
+        // TSan something to chew on). Assertions are invariants, not outcomes: the
+        // interleaving is nondeterministic by design.
+        let store = BridgeDedupStore(maxEntries: 64, ttlMillis: 1_000_000, clock: { 0 })
+
+        DispatchQueue.concurrentPerform(iterations: 2_000) { i in
+            let id = "m-\(i % 100)"
+            _ = store.markIfNew(id)
+            if i % 3 == 0 {
+                store.forget(id)
+            }
+            _ = store.size()
+        }
+
+        XCTAssertLessThanOrEqual(store.size(), 64)
+        // The store still functions after the hammering: a fresh id is new exactly once.
+        XCTAssertTrue(store.markIfNew("post-hammer"))
+        XCTAssertFalse(store.markIfNew("post-hammer"))
+    }
+
     func testExpiredEntryReSightingMovesItToTheBackOfTheEvictionOrder() {
         let store = makeStore(maxEntries: 2, ttlMillis: 1_000)
 

--- a/Tests/MetaRouterTests/webview/BridgeMessageProcessorTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeMessageProcessorTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import MetaRouter
+
+final class BridgeMessageProcessorTests: XCTestCase {
+
+    private final class RecordingSink: BridgeEventSink {
+        var accept = true
+        var enqueued: [BridgeEnvelope] = []
+
+        func enqueue(_ envelope: BridgeEnvelope) -> Bool {
+            if accept { enqueued.append(envelope) }
+            return accept
+        }
+    }
+
+    private func envelopeJson(messageId: String = "m-1", name: String = "product_viewed") -> String {
+        #"{"version":1,"messageId":"\#(messageId)","type":"track","name":"\#(name)","properties":{"sku":"SKU-1"}}"#
+    }
+
+    func testValidEnvelopeIsEnqueuedAndAckedOk() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        let reply = processor.process(envelopeJson())
+
+        XCTAssertEqual(sink.enqueued.count, 1)
+        XCTAssertEqual(sink.enqueued[0].name, "product_viewed")
+        XCTAssertEqual(reply.status, "ok")
+        XCTAssertEqual(reply.messageId, "m-1")
+    }
+
+    func testInvalidEnvelopeIsRejectedAndNeverReachesTheSink() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        let reply = processor.process("{not json")
+
+        XCTAssertEqual(sink.enqueued.count, 0)
+        XCTAssertEqual(reply.status, "error")
+        XCTAssertEqual(reply.code, "malformed_json")
+    }
+
+    func testValidationFailureCarriesTheSpecificErrorCode() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        let reply = processor.process(
+            #"{"version":1,"messageId":"m-1","type":"identify","name":"x"}"#
+        )
+
+        XCTAssertEqual(sink.enqueued.count, 0)
+        XCTAssertEqual(reply.code, "unknown_type")
+        XCTAssertEqual(reply.messageId, "m-1")
+    }
+
+    func testDuplicateMessageIdIsDroppedButStillAckedOk() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        let first = processor.process(envelopeJson(messageId: "m-dup"))
+        let second = processor.process(envelopeJson(messageId: "m-dup"))
+
+        XCTAssertEqual(sink.enqueued.count, 1)
+        XCTAssertEqual(first.status, "ok")
+        XCTAssertEqual(second.status, "ok")
+    }
+
+    func testDistinctMessageIdsAreAllEnqueued() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        _ = processor.process(envelopeJson(messageId: "m-1"))
+        _ = processor.process(envelopeJson(messageId: "m-2"))
+        _ = processor.process(envelopeJson(messageId: "m-3"))
+
+        XCTAssertEqual(sink.enqueued.map { $0.messageId }, ["m-1", "m-2", "m-3"])
+    }
+
+    func testRejectedMessageDoesNotPoisonTheDedupStore() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        // Same messageId, first with an invalid type: the rejection must not record
+        // the id, or the corrected retry would be dropped as a duplicate.
+        _ = processor.process(#"{"version":1,"messageId":"m-1","type":"bogus","name":"x"}"#)
+        let retry = processor.process(envelopeJson(messageId: "m-1"))
+
+        XCTAssertEqual(sink.enqueued.count, 1)
+        XCTAssertEqual(retry.status, "ok")
+    }
+
+    func testRejectedEnqueueNAKsNotReadyAndAllowsARetry() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+        sink.accept = false
+
+        let first = processor.process(envelopeJson(messageId: "m-r"))
+
+        XCTAssertEqual(first.status, "error")
+        XCTAssertEqual(first.code, "not_ready")
+
+        // The failed delivery must not poison dedup: the retry succeeds once the
+        // sink accepts again.
+        sink.accept = true
+        let retry = processor.process(envelopeJson(messageId: "m-r"))
+
+        XCTAssertEqual(retry.status, "ok")
+        XCTAssertEqual(sink.enqueued.count, 1)
+    }
+
+    func testSinkReceivesTheParsedEnvelopeNotTheRawString() {
+        let sink = RecordingSink()
+        let processor = BridgeMessageProcessor(sink: sink)
+
+        _ = processor.process(envelopeJson())
+
+        let envelope = sink.enqueued[0]
+        XCTAssertNotNil(envelope.properties["sku"])
+        XCTAssertEqual(envelope.version, 1)
+    }
+}


### PR DESCRIPTION
**Shortcut:** [sc-39691](https://app.shortcut.com/metarouter/story/39691)
**Epic:** [39685](https://app.shortcut.com/metarouter/epic/39685)
**Android reference:** metarouterio/android-sdk#36 — ported 1:1; divergences listed below.
**Slice 2 of 4** — standalone pipeline; not yet wired in.

> Stacked on #49. Merge that first; this PR will retarget to `main` automatically.

## Summary

The receive pipeline as standalone, unwired classes: raw message → parse/validate → dedup → sink.

- `BridgeDedupStore` — bounded insertion-order store — 1000 entries, FIFO eviction — plus a 5-min TTL, in-memory. Deliberately NOT LRU (per review): recency refresh is exactly what the no-refresh rule forbids, so an "upgrade" to true LRU would quietly break the re-post-loop protection. Duplicates only arrive within the redelivery window of a lost ack, so expired entries read as never-seen; a duplicate does not refresh its window, or a re-post loop could keep an entry alive forever.
- `BridgeMessageProcessor` — produces the reply for every message. Duplicates ack `ok`, not error — the producer's goal (exactly-once enqueue) was already met by the first delivery. **The sink reports whether the event actually entered the delivery path**: a rejected enqueue NAKs `not_ready` and un-records the messageId, so an event dropped downstream never gets a success receipt and a producer retry is not misread as a duplicate of an event that was lost.
- `BridgeEventSink` — single-method seam the wiring slice implements; keeps the pipeline testable without an SDK instance.

## Swift adaptations (vs the Kotlin reference)

- **Clock:** `mach_continuous_time` (millis via timebase), following the monotonic-clock review on the Android PR — Darwin's `elapsedRealtime` equivalent, documented by Apple to keep incrementing across device sleep. `ProcessInfo.systemUptime` (the `uptimeMillis` analogue) pauses in sleep and is deliberately avoided; rationale in a doc comment. Clock injected for tests.
- **LRU:** no `LinkedHashMap` in Swift — dictionary + insertion-order array. Removals are O(n) but n ≤ 1000 and only on forget/expiry/eviction; commented so nobody "optimizes" it later.
- **Constructor bound checks are `precondition`s** (programmer error on SDK-internal constants, never page input), so Android's two `IllegalArgumentException` tests have no XCTest port; the guard lines execute on every store construction in the suite.

## Stack

1. sc-39688 — envelope + validation + wrapper foundation (#49)
2. **this PR** — dedup store + message processor
3. sc-40572 — proxy-owned wiring + `attachWebView` public API
4. sc-40573 — README documentation

## Test plan

- [x] Dedup: hit/miss, TTL expiry (incl. the exact-boundary pin), no-refresh-on-duplicate, LRU eviction, expired-re-sighting eviction order, bound invariants
- [x] Processor: valid→ok, invalid→coded error, duplicate→ok-without-enqueue, rejected enqueue→not_ready + retry succeeds, rejection never poisons dedup
- [x] `swift test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
