### PR TITLE
feat: wire webview bridge + attachWebView public API [3/4]

### DIFF
--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 
 
 /// Injectable dependencies for testing. All fields optional — defaults to production implementations.
@@ -37,8 +38,15 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
     private var initTask: Task<Void, Never>?
     private let lifecycleCoordinator: LifecycleCoordinator?
 
+    // One processor for all attached webviews: bridge messageIds are UUIDs, so a
+    // shared dedup store cannot cross-drop between webviews, and sharing keeps the
+    // memory bound per client rather than per webview.
+    private let bridgeSink = ClientBridgeSink()
+    private let bridgeProcessor: BridgeMessageProcessor
+
     private init(options: InitOptions, deps: AnalyticsDependencies = .production) {
         self.lifecycleState = .initializing
+        self.bridgeProcessor = BridgeMessageProcessor(sink: bridgeSink)
 
         self.options = options
         // Snapshot bundle metadata once — used by both DeviceContextProvider (per-event
@@ -173,6 +181,10 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
                 await self.dispatcher.drainDiskStoreToNetwork()
             }
         }
+
+        // Last: the sink needs self, and self is only safe to hand out once every
+        // stored property above is initialized.
+        self.bridgeSink.client = self
     }
 
     private func handleForeground() {
@@ -528,5 +540,70 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
         Task {
             await coordinator.recordOpenedURL(url, sourceApplication: sourceApplication)
         }
+    }
+
+    /// Bridge sink: a validated, deduplicated webview envelope enters the normal event
+    /// path here. The native messageId, timestamp, identity, and device context are all
+    /// applied by the existing enrichment — the envelope only contributes what native
+    /// cannot know: the event itself and the page it happened on.
+    ///
+    /// Returns whether the event entered the delivery path — the same path native
+    /// events take, including its downstream queue-capacity policy — so the bridge's
+    /// ack never claims delivery for an event the client refused.
+    internal func enqueueBridgeEvent(_ envelope: BridgeEnvelope) -> Bool {
+        guard lifecycleState == .ready, !disabled else {
+            Logger.warn("Cannot enqueue bridge event - SDK not ready (state: \(lifecycleState.rawValue))")
+            return false
+        }
+        Task {
+            let enriched = await enrichmentService.enrichEvent(BaseEvent(
+                type: envelope.type.rawValue,
+                event: envelope.name,
+                properties: envelope.properties,
+                page: envelope.page
+            ))
+            await dispatcher.offer(enriched)
+        }
+        return true
+    }
+
+    /// Bridge attach for direct-client usage (`AnalyticsClient.initialize()`). The
+    /// sink enqueues to THIS client instance, which is correct here: a directly
+    /// created client is caller-owned and is never swapped by `reset()` (that only
+    /// replaces the proxy's client). Do NOT mirror this in the proxy path — there the
+    /// handler must resolve the live client at delivery, since it outlives client
+    /// swaps.
+    @MainActor
+    public func attachWebView(_ webView: WKWebView, allowedOrigins: [String]) {
+        // No lifecycle gate: attach needs nothing from initialized state (the sink's
+        // enqueue has its own READY check), and gating would silently drop attaches
+        // during init — breaking the attach-before-load contract.
+        WebViewBridge.attach(webView, allowedOrigins: allowedOrigins, processor: bridgeProcessor)
+    }
+}
+
+/// Bridge sink for direct-client usage. Holds the client weakly: WebKit retains the
+/// message handler (→ processor → sink) for the WebView's lifetime, and a strong
+/// client reference here would pin a discarded client in memory. A dead client reads
+/// as nil and the message NAKs not_ready — never a silent drop.
+private final class ClientBridgeSink: BridgeEventSink, @unchecked Sendable {
+    private let lock = NSLock()
+    private weak var _client: AnalyticsClient?
+
+    var client: AnalyticsClient? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _client
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _client = newValue
+        }
+    }
+
+    func enqueue(_ envelope: BridgeEnvelope) -> Bool {
+        client?.enqueueBridgeEvent(envelope) ?? false
     }
 }

--- a/Sources/MetaRouter/analytics/AnalyticsClient.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsClient.swift
@@ -547,12 +547,14 @@ internal final class AnalyticsClient: AnalyticsInterface, CustomStringConvertibl
     /// applied by the existing enrichment — the envelope only contributes what native
     /// cannot know: the event itself and the page it happened on.
     ///
-    /// Returns whether the event entered the delivery path — the same path native
-    /// events take, including its downstream queue-capacity policy — so the bridge's
-    /// ack never claims delivery for an event the client refused.
+    /// Returns whether the event was accepted for enrichment and dispatch — false NAKs
+    /// `not_ready`, un-records the id from dedup, and the producer's retry works.
     internal func enqueueBridgeEvent(_ envelope: BridgeEnvelope) -> Bool {
         guard lifecycleState == .ready, !disabled else {
-            Logger.warn("Cannot enqueue bridge event - SDK not ready (state: \(lifecycleState.rawValue))")
+            // Debug-gated: not_ready is an expected, retryable state (init window,
+            // post-reset), and a page firing in a loop must not flood a customer's
+            // device log with warnings.
+            Logger.log("Cannot enqueue bridge event - SDK not ready (state: \(lifecycleState.rawValue))")
             return false
         }
         Task {

--- a/Sources/MetaRouter/analytics/AnalyticsInterface.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsInterface.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 
 public protocol AnalyticsInterface: AnyObject, Sendable {
     func track(_ event: String, properties: [String: Any]?)
@@ -34,4 +35,28 @@ public protocol AnalyticsInterface: AnyObject, Sendable {
     /// using `launchOptions[.url]` / `[.sourceApplication]`. One-shot — cleared
     /// after the next emit.
     func recordOpenedURL(_ url: URL, sourceApplication: String?)
+
+    /// Attach the webview event bridge to a host-owned WebView.
+    ///
+    /// Pages loaded from `allowedOrigins` get a `window.metarouterBridge` object with
+    /// `track(name, properties)` and `page(name, properties)` methods. Calls are
+    /// enveloped in the page, validated and deduplicated natively, enriched with the
+    /// device's identity and context, and delivered through the normal event queue —
+    /// webview activity and native activity arrive as one user.
+    ///
+    /// Call this when the WebView is created, **before** `load(_:)` — the
+    /// registrations only apply to page loads that start afterwards. The SDK never
+    /// discovers webviews on its own: the host owns the WebView, this call is the
+    /// explicit hand-off. Main-actor-isolated because WebView configuration is
+    /// main-thread work; create the WebView and attach in the same place.
+    ///
+    /// Origins must be explicit (`https://host[:port]`); the wildcard `"*"` is
+    /// rejected, since origin scoping is what keeps arbitrary pages from injecting
+    /// events into the native queue.
+    ///
+    /// - Parameters:
+    ///   - webView: The host-owned WebView to bridge
+    ///   - allowedOrigins: Explicit page origins allowed to produce events
+    @MainActor
+    func attachWebView(_ webView: WKWebView, allowedOrigins: [String])
 }

--- a/Sources/MetaRouter/analytics/AnalyticsProxy.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsProxy.swift
@@ -1,9 +1,26 @@
 import Foundation
+import WebKit
 
 internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible,
     CustomDebugStringConvertible, Sendable
 {
     private let state = ProxyState()
+
+    // The bridge is owned here, not by a client: clients are disposable (reset()
+    // creates a new one) while attached WebViews live on, and WebKit retains their
+    // message handlers for the WebView's lifetime. The sink resolves "the current
+    // client" at delivery time — a webview attached before init, or surviving a
+    // reset/re-init cycle, delivers to whichever client is bound when its events
+    // arrive, and events arriving with no ready client are NAKed not_ready instead
+    // of silently lost.
+    private let bridgeClient = BridgeClientBox()
+    private let bridgeProcessor: BridgeMessageProcessor
+
+    init() {
+        bridgeProcessor = BridgeMessageProcessor(
+            sink: ProxyBridgeSink(box: bridgeClient)
+        )
+    }
 
     public var description: String {
         return "MetaRouter.Analytics"
@@ -13,21 +30,36 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
         return "MetaRouter.Analytics(proxy)"
     }
 
+    // bind/unbind publish the client to the bridge's synchronous mirror BEFORE the
+    // actor call, so bridge events racing a bind resolve the new client rather than
+    // NAKing not_ready after the SDK is in fact ready.
     internal func bind(_ real: AnalyticsInterface) {
+        bridgeClient.set(real)
         Task { await state.bind(real) }
     }
 
     internal func unbind() {
+        bridgeClient.clear()
         Task { await state.unbind() }
     }
 
     // Awaitable helpers for barrier APIs
     func _bindAndReplay(_ real: any AnalyticsInterface) async {
+        bridgeClient.set(real)
         await state.bind(real)
     }
 
     func _unbindAndClear() async {
+        bridgeClient.clear()
         await state.unbind()
+    }
+
+    @MainActor
+    public func attachWebView(_ webView: WKWebView, allowedOrigins: [String]) {
+        // Registers immediately regardless of bind state — the WebView registrations
+        // only apply to page loads that start afterwards, so deferring to bind-replay
+        // would lose the wrapper on the host's first load.
+        WebViewBridge.attach(webView, allowedOrigins: allowedOrigins, processor: bridgeProcessor)
     }
 
     public func track(_ event: String, properties: [String: Any]?) {
@@ -115,6 +147,41 @@ extension AnalyticsProxy {
     // Internal helper to seed debug info prior to binding
     internal func setBootstrapDebugInfo(writeKey: String, host: String) {
         Task { await state.setBootstrapDebugInfo(writeKey: writeKey, host: host) }
+    }
+}
+
+/// Synchronous mirror of the actor-held bound client. The bridge sink answers on the
+/// main thread in the middle of a message delivery and cannot await actor isolation,
+/// so bind/unbind also publish the client here — the same role Android's
+/// AtomicReference read fills.
+private final class BridgeClientBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var client: (any AnalyticsInterface)?
+
+    func set(_ c: any AnalyticsInterface) {
+        lock.lock()
+        defer { lock.unlock() }
+        client = c
+    }
+
+    func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        client = nil
+    }
+
+    func get() -> (any AnalyticsInterface)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return client
+    }
+}
+
+private struct ProxyBridgeSink: BridgeEventSink {
+    let box: BridgeClientBox
+
+    func enqueue(_ envelope: BridgeEnvelope) -> Bool {
+        (box.get() as? AnalyticsClient)?.enqueueBridgeEvent(envelope) ?? false
     }
 }
 

--- a/Sources/MetaRouter/enrichment/EventEnrichment.swift
+++ b/Sources/MetaRouter/enrichment/EventEnrichment.swift
@@ -18,8 +18,14 @@ public final class EventEnrichmentService: Sendable {
     public func enrichEvent(
         _ event: EventWithIdentity
     ) async -> EnrichedEventPayload {
-        let context = await contextProvider.getContext()
+        var context = await contextProvider.getContext()
         let messageId = MessageIdGenerator.generate()
+
+        // Bridge-sourced events carry their page facts on the event; native events
+        // leave it nil and context.page stays absent, matching web SDK output.
+        if let page = event.page {
+            context.page = page
+        }
 
         return EnrichedEventPayload(
             type: event.type,
@@ -53,7 +59,8 @@ public final class EventEnrichmentService: Sendable {
             properties: baseEvent.properties,
             traits: baseEvent.traits,
             integrations: baseEvent.integrations,
-            timestamp: timestamp
+            timestamp: timestamp,
+            page: baseEvent.page
         )
 
         return await enrichEvent(eventWithIdentity)

--- a/Sources/MetaRouter/types/Event.swift
+++ b/Sources/MetaRouter/types/Event.swift
@@ -11,6 +11,8 @@ public struct BaseEvent: Codable, Sendable {
     public let traits: [String: CodableValue]?
     public let integrations: [String: CodableValue]?
     public let timestamp: String?
+    /// Set only by the webview bridge — carries the page facts into context.page.
+    public let page: PageContext?
 
     public init(
         type: String,
@@ -21,7 +23,8 @@ public struct BaseEvent: Codable, Sendable {
         properties: [String: CodableValue]? = nil,
         traits: [String: CodableValue]? = nil,
         integrations: [String: CodableValue]? = nil,
-        timestamp: String? = nil
+        timestamp: String? = nil,
+        page: PageContext? = nil
     ) {
         self.type = type
         self.event = event
@@ -32,6 +35,7 @@ public struct BaseEvent: Codable, Sendable {
         self.traits = traits
         self.integrations = integrations
         self.timestamp = timestamp
+        self.page = page
     }
 }
 
@@ -46,6 +50,8 @@ public struct EventWithIdentity: Codable, Sendable {
     public let traits: [String: CodableValue]?
     public let integrations: [String: CodableValue]?
     public let timestamp: String
+    /// Set only by the webview bridge — carries the page facts into context.page.
+    public let page: PageContext?
 
     public init(
         type: String,
@@ -56,7 +62,8 @@ public struct EventWithIdentity: Codable, Sendable {
         properties: [String: CodableValue]? = nil,
         traits: [String: CodableValue]? = nil,
         integrations: [String: CodableValue]? = nil,
-        timestamp: String
+        timestamp: String,
+        page: PageContext? = nil
     ) {
         self.type = type
         self.event = event
@@ -67,6 +74,7 @@ public struct EventWithIdentity: Codable, Sendable {
         self.traits = traits
         self.integrations = integrations
         self.timestamp = timestamp
+        self.page = page
     }
 }
 

--- a/Sources/MetaRouter/types/EventContext.swift
+++ b/Sources/MetaRouter/types/EventContext.swift
@@ -100,6 +100,9 @@ public struct EventContext: Codable, Sendable {
     public let locale: String
     public let timezone: String
     public let additional: [String: CodableValue]
+    /// Present only on bridge-sourced events — set by enrichment from the event's
+    /// page facts; native events have no page to describe and omit the key entirely.
+    public var page: PageContext?
 
     public init(
         app: AppContext,
@@ -110,7 +113,8 @@ public struct EventContext: Codable, Sendable {
         network: NetworkContext? = nil,
         locale: String,
         timezone: String,
-        additional: [String: CodableValue] = [:]
+        additional: [String: CodableValue] = [:],
+        page: PageContext? = nil
     ) {
         self.app = app
         self.device = device
@@ -121,6 +125,7 @@ public struct EventContext: Codable, Sendable {
         self.locale = locale
         self.timezone = timezone
         self.additional = additional
+        self.page = page
     }
 }
 

--- a/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
+++ b/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
@@ -17,8 +17,11 @@ internal protocol BridgeEventSink {
 /// Rejections are logged natively as well as replied — page JS consoles are rarely
 /// watched in production, so the native log is the primary debugging surface for a
 /// misbehaving integration.
-internal final class BridgeMessageProcessor {
+internal final class BridgeMessageProcessor: @unchecked Sendable {
 
+    // @unchecked: both refs are immutable and the store locks internally; the sink
+    // protocol carries no Sendable bound so sink implementations own their thread
+    // safety. process() itself is single-thread-confined regardless (see below).
     private let sink: BridgeEventSink
     private let dedupStore: BridgeDedupStore
 

--- a/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
+++ b/Sources/MetaRouter/webview/BridgeMessageProcessor.swift
@@ -62,7 +62,10 @@ internal final class BridgeMessageProcessor: @unchecked Sendable {
             // a producer retry is not misread as a duplicate of a message that
             // was in fact lost.
             dedupStore.forget(envelope.messageId)
-            Logger.warn(
+            // Debug-gated: rejection here means not_ready, an expected retryable
+            // state — unlike the malformed-input warn above, it is not actionable
+            // and must not flood a customer's device log during the init window.
+            Logger.log(
                 "WebView bridge event not accepted (messageId=\(envelope.messageId))"
             )
             return BridgeReply.error(

--- a/Sources/MetaRouter/webview/BridgeReply.swift
+++ b/Sources/MetaRouter/webview/BridgeReply.swift
@@ -76,7 +76,9 @@ internal struct BridgeReply: Sendable, Equatable {
         )
     }
 
-    private static func jsonString(_ value: String) -> String {
+    /// Internal because the reply-delivery script embeds the serialized reply as a JS
+    /// string literal, and JSON string escaping is exactly the escaping JS needs.
+    static func jsonString(_ value: String) -> String {
         var out = "\""
         for scalar in value.unicodeScalars {
             switch scalar {

--- a/Sources/MetaRouter/webview/WebViewBridge.swift
+++ b/Sources/MetaRouter/webview/WebViewBridge.swift
@@ -43,7 +43,11 @@ internal enum WebViewBridge {
             Logger.warn("attachWebView called with no allowed origins — ignoring.")
             return false
         }
-        let invalid = allowedOrigins.filter {
+        // Normalize BEFORE validating: the pattern is case-sensitive, so a
+        // case-variant scheme would otherwise be rejected as a format problem the
+        // host doesn't have — and everything downstream reasons about one list.
+        let origins = normalizeOriginRules(allowedOrigins)
+        let invalid = origins.filter {
             $0.range(of: originRule, options: .regularExpression) == nil
         }
         if !invalid.isEmpty {
@@ -56,7 +60,19 @@ internal enum WebViewBridge {
             )
             return false
         }
-        let origins = normalizeOriginRules(allowedOrigins)
+        let insecure = origins.filter {
+            $0.hasPrefix("http://") && $0 != "http://localhost" && !$0.hasPrefix("http://localhost:")
+                && $0 != "http://127.0.0.1" && !$0.hasPrefix("http://127.0.0.1:")
+        }
+        if !insecure.isEmpty {
+            // A cleartext origin is spoofable in transit, and the frame-origin check
+            // then trusts an attacker-influenceable value. Fine for local development;
+            // warn (not reject) so a misconfigured production allowlist is visible.
+            Logger.warn(
+                "attachWebView: cleartext origin rules \(insecure) — use https origins "
+                    + "outside local development."
+            )
+        }
         if attached.contains(webView) {
             Logger.warn("attachWebView ignored: this WebView is already attached.")
             return false
@@ -118,14 +134,20 @@ internal enum WebViewBridge {
             allowedOrigins: Set(allowedOrigins)
         )
 
+        // Build the script FIRST: it is the only step here that can throw, and the
+        // un-track-on-failure retry promise in attach() holds only if a failed
+        // registration leaves the controller untouched.
+        let script = try BridgeWrapperScript.build(allowedOrigins: allowedOrigins)
+
         // Remove-then-add: registering a duplicate handler name raises an uncatchable
         // NSException inside WebKit, and two WebViews sharing one WKWebViewConfiguration
         // would hit it even though each WebView is only attached once. Removal is the
-        // API Android lacks (there the duplicate-name throw is caught instead).
+        // API Android lacks (there the duplicate-name throw is caught instead). The
+        // channel name is SDK-reserved: a host handler registered under it would be
+        // silently replaced here.
         controller.removeScriptMessageHandler(forName: BridgeWrapperScript.nativeChannelName)
         controller.add(handler, name: BridgeWrapperScript.nativeChannelName)
 
-        let script = try BridgeWrapperScript.build(allowedOrigins: allowedOrigins)
         // forMainFrameOnly false: allowlisted iframes may produce events, matching
         // Android's behavior; the handler checks every message's frame origin, so a
         // non-allowlisted iframe gets neither the wrapper nor a listening ear.

--- a/Sources/MetaRouter/webview/WebViewBridge.swift
+++ b/Sources/MetaRouter/webview/WebViewBridge.swift
@@ -26,6 +26,12 @@ internal enum WebViewBridge {
     // this bookkeeping, and a duplicate attach warns instead of re-registering.
     private static let attached = NSHashTable<WKWebView>.weakObjects()
 
+    // Registration actually lives on the WKUserContentController, which WebViews can
+    // share through a common WKWebViewConfiguration. Tracked separately so a second
+    // attach on a shared configuration is refused instead of silently replacing the
+    // first attach's handler and allowlist.
+    private static let attachedControllers = NSHashTable<WKUserContentController>.weakObjects()
+
     /// - Returns: true if the attach was accepted and registration ran.
     @discardableResult
     static func attach(
@@ -50,15 +56,31 @@ internal enum WebViewBridge {
             )
             return false
         }
+        let origins = normalizeOriginRules(allowedOrigins)
         if attached.contains(webView) {
             Logger.warn("attachWebView ignored: this WebView is already attached.")
+            return false
+        }
+        let controller = webView.configuration.userContentController
+        if attachedControllers.contains(controller) {
+            // A shared WKWebViewConfiguration is already bridged: its handler and
+            // document-start script live on the controller and cover this WebView
+            // too, under the FIRST attach's allowlist. Re-registering would silently
+            // replace that allowlist for every sharing WebView — refuse instead.
+            Logger.warn(
+                "attachWebView ignored: this WebView shares a WKWebViewConfiguration "
+                    + "whose bridge is already registered — the existing origin allowlist "
+                    + "applies. Give each WebView its own configuration to attach with "
+                    + "different origins."
+            )
             return false
         }
         attached.add(webView)
 
         do {
-            try register(webView, allowedOrigins: allowedOrigins, processor: processor)
-            Logger.log("WebView bridge attached (origins=\(allowedOrigins))")
+            try register(webView, allowedOrigins: origins, processor: processor)
+            attachedControllers.add(controller)
+            Logger.log("WebView bridge attached (origins=\(origins))")
         } catch {
             // A registration failure must not crash the host app — the failure mode is
             // no webview capture, logged. Un-track so a retry works.
@@ -67,6 +89,22 @@ internal enum WebViewBridge {
             return false
         }
         return true
+    }
+
+    /// Scheme and host are case-insensitive and default ports are implied, but both
+    /// origin checks (wrapper `location.origin`, native frame origin) compare exact
+    /// canonical strings — an entry like "https://Shop.Example.com:443" would pass
+    /// validation yet never match anything, leaving the bridge silently inert.
+    static func normalizeOriginRules(_ rules: [String]) -> [String] {
+        return rules.map { rule in
+            var origin = rule.lowercased()
+            if origin.hasPrefix("https://"), origin.hasSuffix(":443") {
+                origin = String(origin.dropLast(4))
+            } else if origin.hasPrefix("http://"), origin.hasSuffix(":80") {
+                origin = String(origin.dropLast(3))
+            }
+            return origin
+        }
     }
 
     private static func register(

--- a/Sources/MetaRouter/webview/WebViewBridge.swift
+++ b/Sources/MetaRouter/webview/WebViewBridge.swift
@@ -1,0 +1,181 @@
+import Foundation
+import WebKit
+
+/// Registers the bridge on a host-owned WebView: the script message handler (receive
+/// side) and the document-start wrapper script (producer side).
+///
+/// Unlike Android's `addWebMessageListener`, WebKit does not scope a message channel to
+/// origins — any page in the WebView can post to a registered handler. Origin scoping
+/// is therefore enforced in two cooperating places: the wrapper script defines nothing
+/// on non-allowlisted pages, and the handler checks each message's frame origin before
+/// processing (neither alone survives a hostile page). Both registrations only affect
+/// page loads that start after attach, which is why hosts must attach before `load`.
+///
+/// `@MainActor` rather than a runtime main-thread hop: WebKit's registration APIs are
+/// main-actor-isolated, so the requirement is enforced at compile time and the attach
+/// bookkeeping needs no locking.
+@MainActor
+internal enum WebViewBridge {
+
+    // Origin rules must be scheme://host[:port] — anything else (paths, trailing
+    // slashes, wildcards) silently never matches the exact-origin checks.
+    private static let originRule = "^https?://[A-Za-z0-9.-]+(:\\d+)?$"
+
+    // WebKit retains the registered handler for the userContentController's lifetime;
+    // tracking attached WebViews weakly means a destroyed WebView is never pinned by
+    // this bookkeeping, and a duplicate attach warns instead of re-registering.
+    private static let attached = NSHashTable<WKWebView>.weakObjects()
+
+    /// - Returns: true if the attach was accepted and registration ran.
+    @discardableResult
+    static func attach(
+        _ webView: WKWebView,
+        allowedOrigins: [String],
+        processor: BridgeMessageProcessor
+    ) -> Bool {
+        if allowedOrigins.isEmpty {
+            Logger.warn("attachWebView called with no allowed origins — ignoring.")
+            return false
+        }
+        let invalid = allowedOrigins.filter {
+            $0.range(of: originRule, options: .regularExpression) == nil
+        }
+        if !invalid.isEmpty {
+            // Origin scoping is the bridge's security boundary; a wildcard would let
+            // any page loaded in this WebView (ads, redirects, hijacked navigation)
+            // inject events into the native queue.
+            Logger.warn(
+                "attachWebView rejects invalid origin rules \(invalid) — "
+                    + "use explicit scheme://host[:port] origins."
+            )
+            return false
+        }
+        if attached.contains(webView) {
+            Logger.warn("attachWebView ignored: this WebView is already attached.")
+            return false
+        }
+        attached.add(webView)
+
+        do {
+            try register(webView, allowedOrigins: allowedOrigins, processor: processor)
+            Logger.log("WebView bridge attached (origins=\(allowedOrigins))")
+        } catch {
+            // A registration failure must not crash the host app — the failure mode is
+            // no webview capture, logged. Un-track so a retry works.
+            attached.remove(webView)
+            Logger.error("WebView bridge attach failed: \(error)")
+            return false
+        }
+        return true
+    }
+
+    private static func register(
+        _ webView: WKWebView,
+        allowedOrigins: [String],
+        processor: BridgeMessageProcessor
+    ) throws {
+        let controller = webView.configuration.userContentController
+        let handler = BridgeScriptMessageHandler(
+            processor: processor,
+            allowedOrigins: Set(allowedOrigins)
+        )
+
+        // Remove-then-add: registering a duplicate handler name raises an uncatchable
+        // NSException inside WebKit, and two WebViews sharing one WKWebViewConfiguration
+        // would hit it even though each WebView is only attached once. Removal is the
+        // API Android lacks (there the duplicate-name throw is caught instead).
+        controller.removeScriptMessageHandler(forName: BridgeWrapperScript.nativeChannelName)
+        controller.add(handler, name: BridgeWrapperScript.nativeChannelName)
+
+        let script = try BridgeWrapperScript.build(allowedOrigins: allowedOrigins)
+        // forMainFrameOnly false: allowlisted iframes may produce events, matching
+        // Android's behavior; the handler checks every message's frame origin, so a
+        // non-allowlisted iframe gets neither the wrapper nor a listening ear.
+        controller.addUserScript(WKUserScript(
+            source: script,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        ))
+    }
+}
+
+/// The receive side of one attach. WebKit retains registered handlers strongly for the
+/// userContentController's lifetime, so this class must never strongly reference the
+/// WebView or a client — either would be pinned forever (the classic WKScriptMessageHandler
+/// retain cycle). It holds only the processor and resolves the WebView per message from
+/// `WKScriptMessage`, which references it weakly.
+internal final class BridgeScriptMessageHandler: NSObject, WKScriptMessageHandler {
+
+    private let processor: BridgeMessageProcessor
+    private let allowedOrigins: Set<String>
+
+    init(processor: BridgeMessageProcessor, allowedOrigins: Set<String>) {
+        self.processor = processor
+        self.allowedOrigins = allowedOrigins
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        // WebKit delivers on the main thread — which is what satisfies process()'s
+        // single-confined-thread rule; assumeIsolated makes that contract visible to
+        // the compiler and traps loudly if it is ever broken.
+        MainActor.assumeIsolated {
+            let securityOrigin = message.frameInfo.securityOrigin
+            let origin = Self.originString(
+                scheme: securityOrigin.protocol,
+                host: securityOrigin.host,
+                port: Int(securityOrigin.port)
+            )
+            guard let reply = processReceived(body: message.body, originString: origin) else {
+                return
+            }
+            // No JavaScriptReplyProxy equivalent on WebKit: acks are delivered by
+            // invoking the wrapper-defined channel's onmessage, in the frame (and
+            // content world) the message came from.
+            message.webView?.evaluateJavaScript(
+                Self.replyScript(for: reply),
+                in: message.frameInfo,
+                in: .page
+            ) { result in
+                if case .failure(let error) = result {
+                    // Debug-level: a page that navigated away mid-ack fails here
+                    // routinely and is not actionable.
+                    Logger.log("WebView bridge reply delivery failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// The testable core of the receive side: frame-origin gate → processor.
+    /// Returns nil when no reply should be sent (non-allowlisted frame, non-string
+    /// body) — a hostile frame gets silence, not an oracle.
+    func processReceived(body: Any, originString: String) -> BridgeReply? {
+        guard allowedOrigins.contains(originString) else {
+            // The native half of the security model (the wrapper's location.origin
+            // self-check is the page half). Debug-level: a hostile page could spam
+            // this, so it must not flood production logs.
+            Logger.log("WebView bridge dropped message from non-allowlisted origin \(originString)")
+            return nil
+        }
+        guard let raw = body as? String else { return nil }
+        return processor.process(raw)
+    }
+
+    /// Ack delivery script. The reply JSON rides as a JS string literal (JSON string
+    /// escaping is valid JS escaping), so the page-visible shape matches Android:
+    /// `onmessage` receives an event-like object whose `data` is the reply string.
+    static func replyScript(for reply: BridgeReply) -> String {
+        let channel = "window.\(BridgeWrapperScript.nativeChannelName)"
+        let payload = BridgeReply.jsonString(reply.toJson())
+        return "\(channel) && typeof \(channel).onmessage === 'function' && \(channel).onmessage({ data: \(payload) });"
+    }
+
+    /// `WKSecurityOrigin` reports 0 for a scheme's default port; the wrapper's
+    /// `location.origin` omits default ports the same way, so allowlist entries
+    /// written without default ports match both checks consistently.
+    static func originString(scheme: String, host: String, port: Int) -> String {
+        port == 0 ? "\(scheme)://\(host)" : "\(scheme)://\(host):\(port)"
+    }
+}

--- a/Tests/MetaRouterTests/Helpers/TestHelpers.swift
+++ b/Tests/MetaRouterTests/Helpers/TestHelpers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 
 @testable import MetaRouter
 
@@ -159,6 +160,11 @@ final class MockAnalyticsInterface: AnalyticsInterface, @unchecked Sendable {
     func recordOpenedURL(_ url: URL, sourceApplication: String?) {
         recordCall(.recordOpenedURL(url: url, sourceApplication: sourceApplication))
     }
+
+    @MainActor
+    func attachWebView(_ webView: WKWebView, allowedOrigins: [String]) {
+        recordCall(.attachWebView(allowedOrigins: allowedOrigins))
+    }
 }
 
 // Analytics Call Recording
@@ -180,6 +186,7 @@ enum AnalyticsCall: Equatable {
     case clearAdvertisingId
     case setTracing(enabled: Bool)
     case recordOpenedURL(url: URL, sourceApplication: String?)
+    case attachWebView(allowedOrigins: [String])
 }
 
 // CodableValue Test Extensions

--- a/Tests/MetaRouterTests/webview/BridgeEventPlumbingTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeEventPlumbingTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import MetaRouter
+
+/// Covers the plumbing that carries a bridge envelope's page facts onto the outbound
+/// payload: BaseEvent.page → enrichment → context.page.
+final class BridgeEventPlumbingTests: XCTestCase {
+
+    private var enrichment: EventEnrichmentService!
+    private var identityManager: IdentityManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        identityManager = IdentityManager(writeKey: "test-write-key", host: "https://test.metarouter.com")
+        await identityManager.initialize()
+        enrichment = EventEnrichmentService(
+            contextProvider: MockContextProvider(),
+            identityManager: identityManager,
+            writeKey: "test-write-key"
+        )
+    }
+
+    override func tearDown() {
+        enrichment = nil
+        identityManager = nil
+        super.tearDown()
+    }
+
+    func testBridgeEventPageFactsLandOnContextPage() async {
+        let enriched = await enrichment.enrichEvent(BaseEvent(
+            type: EventType.page.rawValue,
+            event: "page_view",
+            page: PageContext(
+                url: "https://www.metarouter.com/booking",
+                title: "Book",
+                referrer: "https://www.metarouter.com/"
+            )
+        ))
+
+        XCTAssertEqual(enriched.context.page?.url, "https://www.metarouter.com/booking")
+        XCTAssertEqual(enriched.context.page?.title, "Book")
+        XCTAssertEqual(enriched.context.page?.referrer, "https://www.metarouter.com/")
+    }
+
+    func testNativeEventsCarryNoPageContext() async throws {
+        let enriched = await enrichment.enrichEvent(BaseEvent(
+            type: EventType.track.rawValue,
+            event: "native_action"
+        ))
+
+        XCTAssertNil(enriched.context.page)
+        // And the key is absent from the wire form, matching web SDK output for
+        // native traffic — not serialized as null.
+        let json = String(decoding: try JSONEncoder().encode(enriched.context), as: UTF8.self)
+        XCTAssertFalse(json.contains("\"page\""))
+    }
+
+    func testIdentityAndMessageIdComeFromNativeEnrichmentNotTheEnvelope() async {
+        let enriched = await enrichment.enrichEvent(BaseEvent(
+            type: EventType.track.rawValue,
+            event: "product_viewed",
+            page: PageContext(url: "https://www.metarouter.com/search")
+        ))
+
+        let nativeAnonymousId = await identityManager.getOrCreateAnonymousId()
+        XCTAssertEqual(enriched.anonymousId, nativeAnonymousId)
+        // The envelope's messageId exists for bridge dedup only; the outbound event
+        // gets a native ID like every other event.
+        XCTAssertTrue(MessageIdGenerator.isValid(enriched.messageId))
+    }
+}

--- a/Tests/MetaRouterTests/webview/BridgeEventPlumbingTests.swift
+++ b/Tests/MetaRouterTests/webview/BridgeEventPlumbingTests.swift
@@ -54,6 +54,26 @@ final class BridgeEventPlumbingTests: XCTestCase {
         XCTAssertFalse(json.contains("\"page\""))
     }
 
+    func testBridgedPageEventCarriesItsNameInTheEventField() async {
+        // Bridged page events put the name in `event` with no properties["name"] —
+        // the shape the other MetaRouter SDKs emit for page(). The iOS-native
+        // createPageEvent instead writes properties["name"] with a nil `event`; that
+        // pre-existing divergence is pinned here so a change to either side is a
+        // deliberate one, not an accident.
+        let bridged = await enrichment.enrichEvent(BaseEvent(
+            type: EventType.page.rawValue,
+            event: "Checkout",
+            properties: [:],
+            page: PageContext(url: "https://www.metarouter.com/checkout")
+        ))
+        XCTAssertEqual(bridged.event, "Checkout")
+        XCTAssertNil(bridged.properties?["name"])
+
+        let native = await enrichment.createPageEvent(name: "Checkout")
+        XCTAssertNil(native.event)
+        XCTAssertEqual(native.properties?["name"]?.stringValue, "Checkout")
+    }
+
     func testIdentityAndMessageIdComeFromNativeEnrichmentNotTheEnvelope() async {
         let enriched = await enrichment.enrichEvent(BaseEvent(
             type: EventType.track.rawValue,

--- a/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
+++ b/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
@@ -89,11 +89,14 @@ final class WebViewBridgeTests: XCTestCase {
             ["http://localhost:8080", "https://x.com:8443"]
         )
 
+        // End-to-end through attach, with the case variance on the SCHEME: rules are
+        // normalized before validation, so a case-variant scheme must register rather
+        // than being rejected as a format problem the host doesn't have.
         let webView = WKWebView()
         let (_, processor) = makeProcessor()
         XCTAssertTrue(WebViewBridge.attach(
             webView,
-            allowedOrigins: ["https://Shop.MetaRouter.com:443"],
+            allowedOrigins: ["HTTPS://Shop.MetaRouter.com:443"],
             processor: processor
         ))
         let script = webView.configuration.userContentController.userScripts[0].source

--- a/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
+++ b/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
@@ -1,0 +1,160 @@
+import WebKit
+import XCTest
+@testable import MetaRouter
+
+final class WebViewBridgeTests: XCTestCase {
+
+    private final class RecordingSink: BridgeEventSink {
+        var accept = true
+        var enqueued: [BridgeEnvelope] = []
+
+        func enqueue(_ envelope: BridgeEnvelope) -> Bool {
+            if accept { enqueued.append(envelope) }
+            return accept
+        }
+    }
+
+    private let origins = ["https://www.metarouter.com"]
+
+    private func makeProcessor() -> (RecordingSink, BridgeMessageProcessor) {
+        let sink = RecordingSink()
+        return (sink, BridgeMessageProcessor(sink: sink))
+    }
+
+    // MARK: - Attach
+
+    @MainActor
+    func testAttachRegistersHandlerAndWrapperScript() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        let attached = WebViewBridge.attach(webView, allowedOrigins: origins, processor: processor)
+
+        XCTAssertTrue(attached)
+        let scripts = webView.configuration.userContentController.userScripts
+        XCTAssertEqual(scripts.count, 1)
+        XCTAssertTrue(scripts[0].source.contains("window.metarouterBridge"))
+        XCTAssertEqual(scripts[0].injectionTime, .atDocumentStart)
+        XCTAssertFalse(scripts[0].isForMainFrameOnly)
+    }
+
+    @MainActor
+    func testAttachRejectsTheWildcardOrigin() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        let attached = WebViewBridge.attach(webView, allowedOrigins: ["*"], processor: processor)
+
+        XCTAssertFalse(attached)
+        XCTAssertTrue(webView.configuration.userContentController.userScripts.isEmpty)
+    }
+
+    @MainActor
+    func testAttachRejectsAnEmptyOriginList() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: [], processor: processor))
+    }
+
+    @MainActor
+    func testAttachRejectsMalformedOriginRulesInsteadOfFailingDownstream() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        // Each of these would silently never match the exact-origin checks.
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: ["https://x.com/"], processor: processor))
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: ["https://x.com/path"], processor: processor))
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: ["x.com"], processor: processor))
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: ["https://*.x.com"], processor: processor))
+        XCTAssertTrue(webView.configuration.userContentController.userScripts.isEmpty)
+    }
+
+    @MainActor
+    func testSecondAttachOnTheSameWebViewIsRejected() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        XCTAssertTrue(WebViewBridge.attach(webView, allowedOrigins: origins, processor: processor))
+        // Re-registering must be refused rather than re-adding the handler and script.
+        XCTAssertFalse(WebViewBridge.attach(webView, allowedOrigins: origins, processor: processor))
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 1)
+    }
+
+    // MARK: - Message flow (via the handler's testable seam; WKScriptMessage is not
+    // constructible in tests, so the frame-origin string and body arrive as the
+    // delegate method would pass them)
+
+    func testReceivedMessageFlowsThroughTheProcessorAndAcks() {
+        let (sink, processor) = makeProcessor()
+        let handler = BridgeScriptMessageHandler(processor: processor, allowedOrigins: Set(origins))
+
+        let reply = handler.processReceived(
+            body: #"{"version":1,"messageId":"m-1","type":"page","name":"page_view","properties":{}}"#,
+            originString: "https://www.metarouter.com"
+        )
+
+        XCTAssertEqual(sink.enqueued.count, 1)
+        XCTAssertEqual(sink.enqueued[0].name, "page_view")
+        XCTAssertEqual(reply?.toJson(), #"{"status":"ok","messageId":"m-1"}"#)
+    }
+
+    func testInvalidMessageIsRejectedWithAReplyAndNeverEnqueued() {
+        let (sink, processor) = makeProcessor()
+        let handler = BridgeScriptMessageHandler(processor: processor, allowedOrigins: Set(origins))
+
+        let reply = handler.processReceived(
+            body: "{not json",
+            originString: "https://www.metarouter.com"
+        )
+
+        XCTAssertEqual(sink.enqueued.count, 0)
+        XCTAssertEqual(reply?.code, "malformed_json")
+    }
+
+    func testNonStringMessageBodyIsIgnoredWithoutAReply() {
+        let (sink, processor) = makeProcessor()
+        let handler = BridgeScriptMessageHandler(processor: processor, allowedOrigins: Set(origins))
+
+        XCTAssertNil(handler.processReceived(body: NSNull(), originString: "https://www.metarouter.com"))
+        XCTAssertNil(handler.processReceived(body: 42, originString: "https://www.metarouter.com"))
+        XCTAssertEqual(sink.enqueued.count, 0)
+    }
+
+    func testMessageFromNonAllowlistedFrameIsIgnoredWithoutAReply() {
+        let (sink, processor) = makeProcessor()
+        let handler = BridgeScriptMessageHandler(processor: processor, allowedOrigins: Set(origins))
+
+        // A valid envelope from the wrong frame gets silence, not an oracle: no reply
+        // reveals whether the allowlist check or the parser rejected it.
+        let reply = handler.processReceived(
+            body: #"{"version":1,"messageId":"m-1","type":"track","name":"x"}"#,
+            originString: "https://evil.example"
+        )
+
+        XCTAssertNil(reply)
+        XCTAssertEqual(sink.enqueued.count, 0)
+    }
+
+    // MARK: - Reply delivery
+
+    func testReplyScriptInvokesOnmessageWithTheReplyAsAStringPayload() {
+        let script = BridgeScriptMessageHandler.replyScript(for: .ok("m-1"))
+
+        XCTAssertTrue(script.contains("window.__metaRouterNativeChannel.onmessage"))
+        // The reply rides as a JS string literal (Android parity: onmessage data is a
+        // string), so its quotes must arrive escaped.
+        XCTAssertTrue(script.contains(#"{ data: "{\"status\":\"ok\",\"messageId\":\"m-1\"}" }"#))
+    }
+
+    func testOriginStringOmitsDefaultPortAndKeepsExplicitPort() {
+        XCTAssertEqual(
+            BridgeScriptMessageHandler.originString(scheme: "https", host: "www.metarouter.com", port: 0),
+            "https://www.metarouter.com"
+        )
+        XCTAssertEqual(
+            BridgeScriptMessageHandler.originString(scheme: "http", host: "localhost", port: 8080),
+            "http://localhost:8080"
+        )
+    }
+}

--- a/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
+++ b/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
@@ -71,6 +71,59 @@ final class WebViewBridgeTests: XCTestCase {
     }
 
     @MainActor
+    func testOriginRulesAreNormalizedSoCaseAndDefaultPortVariantsMatch() {
+        // Scheme/host case and explicit default ports pass validation but would never
+        // match the canonical origin the page reports — normalized at attach so the
+        // allowlist entry a host plausibly writes actually works.
+        XCTAssertEqual(
+            WebViewBridge.normalizeOriginRules(["https://Shop.MetaRouter.com:443"]),
+            ["https://shop.metarouter.com"]
+        )
+        XCTAssertEqual(
+            WebViewBridge.normalizeOriginRules(["HTTP://Example.com:80"]),
+            ["http://example.com"]
+        )
+        // Non-default ports are meaningful and preserved.
+        XCTAssertEqual(
+            WebViewBridge.normalizeOriginRules(["http://localhost:8080", "https://x.com:8443"]),
+            ["http://localhost:8080", "https://x.com:8443"]
+        )
+
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+        XCTAssertTrue(WebViewBridge.attach(
+            webView,
+            allowedOrigins: ["https://Shop.MetaRouter.com:443"],
+            processor: processor
+        ))
+        let script = webView.configuration.userContentController.userScripts[0].source
+        XCTAssertTrue(script.contains(#"["https://shop.metarouter.com"]"#))
+        XCTAssertFalse(script.contains("Shop.MetaRouter.com"))
+    }
+
+    @MainActor
+    func testSecondAttachOnASharedConfigurationIsRefusedWithoutClobberingTheFirst() {
+        let configuration = WKWebViewConfiguration()
+        let webViewA = WKWebView(frame: .zero, configuration: configuration)
+        let webViewB = WKWebView(frame: .zero, configuration: configuration)
+        let (_, processor) = makeProcessor()
+
+        XCTAssertTrue(WebViewBridge.attach(
+            webViewA, allowedOrigins: ["https://a.metarouter.com"], processor: processor
+        ))
+        // Registration lives on the shared controller: re-registering for B would
+        // silently replace A's handler and allowlist, dropping all of A's events.
+        XCTAssertFalse(WebViewBridge.attach(
+            webViewB, allowedOrigins: ["https://b.metarouter.com"], processor: processor
+        ))
+
+        let scripts = configuration.userContentController.userScripts
+        XCTAssertEqual(scripts.count, 1)
+        XCTAssertTrue(scripts[0].source.contains("a.metarouter.com"))
+        XCTAssertFalse(scripts[0].source.contains("b.metarouter.com"))
+    }
+
+    @MainActor
     func testSecondAttachOnTheSameWebViewIsRejected() {
         let webView = WKWebView()
         let (_, processor) = makeProcessor()


### PR DESCRIPTION
**Shortcut:** [sc-40572](https://app.shortcut.com/metarouter/story/40572)
**Epic:** [39685](https://app.shortcut.com/metarouter/epic/39685)
**Android reference:** metarouterio/android-sdk#37 — same topology, WebKit transport.
**Slice 3 of 4** — first slice where the bridge works end-to-end. Verified live on simulator against a real cluster: bridged events arrived carrying native identity (userId from a login, advertisingId via the app's ATT flow), device context, and `context.page` — with all rejection codes, the `unsupported_version` echo, and dedup observed on-page and in native logs.

> Stacked on #50. Merge #49–#50 first; this PR will retarget automatically.

## Summary

### Public API
- `attachWebView(_:allowedOrigins:)` across `AnalyticsInterface`, `AnalyticsProxy`, and `AnalyticsClient`. Explicit host hand-off — the SDK never discovers webviews on its own. Wildcards rejected: origin scoping is the security boundary that keeps arbitrary pages (ads, redirects) from injecting events into the native queue.

### Ownership topology — mirrors the Android decision
The bridge is owned by the **long-lived proxy, not a client instance**. Clients are disposable (`reset()` creates a new one) while attached WebViews live on, and WebKit retains their message handlers for the WebView's lifetime. The sink resolves "the current client" at delivery time; events arriving with no ready client NAK `not_ready`. Attach registers **immediately** regardless of bind state — registrations only affect page loads that start afterwards, so deferring to bind-replay would lose the wrapper on the host's first load. The client is published to a lock-based synchronous mirror *before* actor bind/replay (the sink answers mid-message on the main thread and cannot await actor isolation) — same ordering the Android replay-hardening fix established.

### WebKit divergences (each commented at the site)
- **Origin scoping is not platform-enforced on iOS** — there is no `addWebMessageListener` equivalent. The handler verifies every message's `frameInfo.securityOrigin` against the allowlist; a message from a non-allowlisted frame gets **silence, not an error reply** (no oracle for hostile frames). Wrapper self-check + native frame check carry the security model together.
- **`@MainActor` instead of a runtime hop** — the main-thread rule is enforced at compile time, which also removes all locking from the attach bookkeeping.
- **Replies via `evaluateJavaScript`** into the wrapper's channel shim (`onmessage({data: …})`), targeted at the sending frame and content world; no `JavaScriptReplyProxy` exists. Page-visible reply shape identical to Android.
- **Remove-then-add handler registration** — a duplicate handler name raises an *uncatchable* NSException when two WebViews share one `WKWebViewConfiguration`; removal is the API Android lacks (there the duplicate-name throw is caught instead).
- **Retain-cycle discipline** — WebKit retains registered handlers strongly; the handler holds only the processor and resolves the WebView weakly per message. The direct-client sink holds its client weakly. Detach-on-reset deliberately **not** implemented despite `removeScriptMessageHandler` existing: attachment is WebView-scoped for cross-platform parity, and the resolve-at-delivery sink makes detach unnecessary.
- `forMainFrameOnly: false` — allowlisted iframes may produce events, matching Android; the per-frame origin check covers the rest.

### Event path
- `context.page` (`PageContext`) carries the envelope's page facts; native events leave it absent (not null) — pinned by test.
- The sink maps envelope → `BaseEvent` through the normal channel: identity, device context, timestamp, and messageId all come from existing enrichment — the envelope contributes only what native cannot know.

## Test notes

- `WKScriptMessage` is not constructible in tests, so message-flow tests go through the handler's `processReceived(body:originString:)` seam; attach tests use real `WKWebView`s (they run on macOS).
- Android's "registration throw is caught and un-tracks" test has no port: with remove-then-add, no triggerable registration failure remains (the catch guards only the script-build throw, whose inputs are validated earlier).

## Stack

1. sc-39688 — envelope + validation + wrapper foundation (#49)
2. sc-39691 — dedup store + message processor (#50)
3. **this PR** — proxy-owned wiring + `attachWebView` public API
4. sc-40573 — README documentation

## Test plan

- [x] Attach: registration with handler + document-start script, wildcard/malformed/empty-origin rejection, duplicate-attach rejection
- [x] Message flow: valid→enqueued+acked, invalid→coded error, non-string body ignored, non-allowlisted frame ignored without reply
- [x] Enrichment: bridge events land `context.page`; native events omit the key entirely; identity/messageId native-sourced
- [x] `swift test` passes
- [x] Manual E2E on simulator against a live cluster (wrapper acks and every error code observed in-page; events accepted with 2xx carrying `userId`, `advertisingId`, and `context.page`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)