### PR TITLE
feat: release-safe InitOptions — assert in debug, degrade in release

### DIFF
--- a/Sources/MetaRouter/MetaRouter.swift
+++ b/Sources/MetaRouter/MetaRouter.swift
@@ -9,8 +9,11 @@ public enum MetaRouter {
 
     // Synchronous-binding initializer for deterministic testing/flows that require immediate binding
     public static func initializeAndWait(with options: InitOptions) async -> AnalyticsInterface {
-        proxy.setBootstrapDebugInfo(writeKey: options.writeKey, host: options.ingestionHost.absoluteString)
-        let real = AnalyticsClient.initialize(options: options)
+        guard passesConfigGate(options) else {
+            await disableSession()
+            return proxy
+        }
+        let real = AnalyticsClient.initialize(options: options.discardingConfigCallback())
         await store.set(real)
         await proxy._bindAndReplay(real)
         return proxy
@@ -19,9 +22,12 @@ public enum MetaRouter {
    @discardableResult
     public static func createAnalyticsClient(with options: InitOptions) -> AnalyticsInterface {
         // Return the proxy immediately; bind happens async (proxy queues pre-bind calls)
-        proxy.setBootstrapDebugInfo(writeKey: options.writeKey, host: options.ingestionHost.absoluteString)
+        guard passesConfigGate(options) else {
+            Task { await disableSession() }
+            return proxy
+        }
         Task {
-            let real = AnalyticsClient.initialize(options: options)
+            let real = AnalyticsClient.initialize(options: options.discardingConfigCallback())
             if await store.setIfNil(real) {
                 proxy.bind(real)
             } else {
@@ -29,6 +35,34 @@ public enum MetaRouter {
             }
         }
         return proxy
+    }
+
+    /// The release half of the invalid-config contract: construction recorded the
+    /// verdict, this is where it takes effect. On invalid config no client is created —
+    /// the proxy is still returned so call sites never see nil, and the SDK is inert
+    /// for the session, mirroring the 401/403/404 graceful-disable for local config.
+    /// Log and callback fire synchronously on the caller's thread.
+    private static func passesConfigGate(_ options: InitOptions) -> Bool {
+        proxy.setBootstrapDebugInfo(
+            writeKey: options.writeKey,
+            host: options.ingestionHost.absoluteString,
+            configError: options.configError?.description
+        )
+        guard let error = options.configError else { return true }
+        Logger.error("MetaRouter disabled for this session — \(error.description)")
+        options.onConfigError?(error)
+        return false
+    }
+
+    /// An initialize call with invalid config disables the whole session, even a
+    /// re-initialize over a previously valid client: silently keeping the stale
+    /// client running would mask the config error (a bound client also shadows the
+    /// bootstrap debug info that reports it). Fail visible, not quiet. Marking the
+    /// proxy disabled also resolves any suspended awaiters — no bind is coming.
+    private static func disableSession() async {
+        await proxy._unbindAndClear()
+        await store.clear()
+        await proxy._markConfigDisabled()
     }
 
     public enum Analytics {

--- a/Sources/MetaRouter/MetaRouter.swift
+++ b/Sources/MetaRouter/MetaRouter.swift
@@ -13,6 +13,7 @@ public enum MetaRouter {
             await disableSession()
             return proxy
         }
+        await proxy._clearConfigDisabled()
         let real = AnalyticsClient.initialize(options: options.discardingConfigCallback())
         await store.set(real)
         await proxy._bindAndReplay(real)
@@ -27,6 +28,7 @@ public enum MetaRouter {
             return proxy
         }
         Task {
+            await proxy._clearConfigDisabled()
             let real = AnalyticsClient.initialize(options: options.discardingConfigCallback())
             if await store.setIfNil(real) {
                 proxy.bind(real)

--- a/Sources/MetaRouter/analytics/AnalyticsProxy.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsProxy.swift
@@ -60,6 +60,10 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
         await state.markConfigDisabled()
     }
 
+    func _clearConfigDisabled() async {
+        await state.clearConfigDisabled()
+    }
+
     @MainActor
     public func attachWebView(_ webView: WKWebView, allowedOrigins: [String]) {
         // Registers immediately regardless of bind state — the WebView registrations
@@ -236,6 +240,17 @@ private actor ProxyState {
     func unbind() {
         real = nil
         queue.removeAll()
+        // reset() tears down a session without refusing one. Leaving the flag set
+        // would make every later awaiting call resolve degraded for a session that
+        // was never gated. disableSession() marks it again after this returns.
+        configDisabled = false
+    }
+
+    /// Clears the refusal ahead of a bind that is still being built, so callers
+    /// awaiting in the pre-bind window suspend for the incoming client instead of
+    /// resolving degraded against the previous session's verdict.
+    func clearConfigDisabled() {
+        configDisabled = false
     }
 
     func markConfigDisabled() {

--- a/Sources/MetaRouter/analytics/AnalyticsProxy.swift
+++ b/Sources/MetaRouter/analytics/AnalyticsProxy.swift
@@ -54,6 +54,12 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
         await state.unbind()
     }
 
+    /// Invalid-config refusal: no bind is coming this session, so waiters must
+    /// resolve degraded rather than suspend forever.
+    func _markConfigDisabled() async {
+        await state.markConfigDisabled()
+    }
+
     @MainActor
     public func attachWebView(_ webView: WKWebView, allowedOrigins: [String]) {
         // Registers immediately regardless of bind state — the WebView registrations
@@ -145,8 +151,8 @@ internal final class AnalyticsProxy: AnalyticsInterface, CustomStringConvertible
 
 extension AnalyticsProxy {
     // Internal helper to seed debug info prior to binding
-    internal func setBootstrapDebugInfo(writeKey: String, host: String) {
-        Task { await state.setBootstrapDebugInfo(writeKey: writeKey, host: host) }
+    internal func setBootstrapDebugInfo(writeKey: String, host: String, configError: String? = nil) {
+        Task { await state.setBootstrapDebugInfo(writeKey: writeKey, host: host, configError: configError) }
     }
 }
 
@@ -207,10 +213,16 @@ private actor ProxyState {
     private var queue: [Call] = []
     private let cap = 20
     private var bootstrapDebugInfo: [String: CodableValue] = [:]
-    private var bindContinuations: [CheckedContinuation<AnalyticsInterface, Never>] = []
+    private var bindContinuations: [CheckedContinuation<AnalyticsInterface?, Never>] = []
+    // Set when initialize() was refused over invalid config: no bind is coming this
+    // session, so awaiting APIs must resolve (degraded) instead of suspending forever
+    // — a permanent hang would be a worse outcome than the crash this replaces.
+    private var configDisabled = false
 
     func bind(_ client: AnalyticsInterface) {
         real = client
+        // A successful (re)initialize supersedes an earlier config refusal.
+        configDisabled = false
         // Replay queued calls
         for call in queue { forward(call) }
         queue.removeAll()
@@ -226,8 +238,18 @@ private actor ProxyState {
         queue.removeAll()
     }
 
-    private func awaitClient() async -> AnalyticsInterface {
+    func markConfigDisabled() {
+        configDisabled = true
+        // Anyone already suspended is waiting for a bind that will never come.
+        for continuation in bindContinuations {
+            continuation.resume(returning: nil)
+        }
+        bindContinuations.removeAll()
+    }
+
+    private func awaitClient() async -> AnalyticsInterface? {
         if let client = real { return client }
+        if configDisabled { return nil }
         return await withCheckedContinuation { continuation in
             bindContinuations.append(continuation)
         }
@@ -242,7 +264,7 @@ private actor ProxyState {
         }
     }
 
-    func setBootstrapDebugInfo(writeKey: String, host: String) {
+    func setBootstrapDebugInfo(writeKey: String, host: String, configError: String? = nil) {
         let maskedKey = writeKey.count > 4
             ? "***" + writeKey.suffix(4)
             : "***"
@@ -250,10 +272,15 @@ private actor ProxyState {
             "writeKey": .string(maskedKey),
             "ingestionHost": .string(host),
         ]
+        if let configError {
+            bootstrapDebugInfo["configError"] = .string(configError)
+        }
     }
 
     func getAnonymousId() async -> String {
-        let client = await awaitClient()
+        // Empty only on a config-disabled session — the degraded-but-resolved answer;
+        // normal operation still awaits initialization and never returns empty.
+        guard let client = await awaitClient() else { return "" }
         return await client.getAnonymousId()
     }
 

--- a/Sources/MetaRouter/analytics/InitOptions.swift
+++ b/Sources/MetaRouter/analytics/InitOptions.swift
@@ -1,5 +1,23 @@
 import Foundation
 
+/// Why construction was invalid. Recorded on the options rather than thrown: a throwing
+/// initializer would leave the diagnostics callback nowhere to live, and an integrator
+/// sourcing config from a remote system would `try!` straight back into the crash this
+/// contract exists to prevent. `initialize(with:)` reads the verdict and degrades.
+public enum ConfigError: Error, Equatable, Sendable, CustomStringConvertible {
+    case emptyWriteKey
+    case invalidIngestionHost(String)
+
+    public var description: String {
+        switch self {
+        case .emptyWriteKey:
+            return "writeKey must not be empty or whitespace-only"
+        case .invalidIngestionHost(let raw):
+            return "ingestionHost must be an http(s) URL, got \"\(raw)\""
+        }
+    }
+}
+
 public struct InitOptions: Sendable {
     public let writeKey: String
     public let ingestionHost: URL
@@ -9,6 +27,37 @@ public struct InitOptions: Sendable {
     public let maxDiskEvents: Int
     public let trackLifecycleEvents: Bool
 
+    /// Non-nil when construction received invalid config. The SDK never crashes the
+    /// host over local config in release — `initialize(with:)` sees this, logs an
+    /// always-on error, fires `onConfigError`, and leaves the SDK inert for the
+    /// session, mirroring the 401/403/404 graceful-disable. Debug builds fail fast at
+    /// the construction site instead.
+    public let configError: ConfigError?
+
+    /// Fired synchronously by `initialize(with:)` (caller's thread) when
+    /// `configError` is non-nil — the programmatic complement to the error log, so a
+    /// host can surface misconfiguration to its own diagnostics.
+    public private(set) var onConfigError: (@Sendable (ConfigError) -> Void)?
+
+    /// The callback only ever fires from the config gate, before a client exists —
+    /// the client's copy of the options must not pin the closure (and whatever host
+    /// state it captures) for the whole session.
+    internal func discardingConfigCallback() -> InitOptions {
+        var copy = self
+        copy.onConfigError = nil
+        return copy
+    }
+
+    /// Debug-only fail-fast, injectable: assertions are active in test builds too, so
+    /// tests exercising the release-degrade path swap this to observe instead of trap.
+    internal nonisolated(unsafe) static var debugAssert: @Sendable (String) -> Void = {
+        assertionFailure($0)
+    }
+
+    // Stored on invalid-host construction so `ingestionHost` stays non-optional; the
+    // SDK is inert in that state and never dereferences it.
+    private static let unsetHost = URL(string: "invalid://unset")!
+
     public init(
         writeKey: String,
         ingestionHost: URL,
@@ -16,31 +65,23 @@ public struct InitOptions: Sendable {
         debug: Bool = false,
         maxQueueEvents: Int = 2000,
         maxDiskEvents: Int = 10000,
-        trackLifecycleEvents: Bool = false
+        trackLifecycleEvents: Bool = false,
+        onConfigError: (@Sendable (ConfigError) -> Void)? = nil
     ) {
-        precondition(!writeKey.isEmpty, "writeKey must not be empty")
-
-        // reject if it ends with /
-        let raw = ingestionHost.absoluteString
-        precondition(!raw.hasSuffix("/"), "ingestionHost must not end with a slash")
-
-        precondition(maxDiskEvents >= 0, "maxDiskEvents must be >= 0 (use 0 to disable disk persistence)")
-
-        self.writeKey = writeKey
-        self.ingestionHost = ingestionHost
-        self.flushIntervalSeconds = max(1, flushIntervalSeconds)
-        self.debug = debug
-        self.maxQueueEvents = max(1, maxQueueEvents)
-        self.maxDiskEvents = maxDiskEvents
-        self.trackLifecycleEvents = trackLifecycleEvents
-
-        if self.maxDiskEvents > 0 && self.maxDiskEvents < self.maxQueueEvents {
-            Logger.warn("maxDiskEvents (\(self.maxDiskEvents)) is less than maxQueueEvents (\(self.maxQueueEvents)) — memory can hold more events than disk can preserve; events may be dropped during background flush")
-        }
+        // One normalization site: the String initializer owns trimming and the
+        // trailing-slash rule; a URL is just its string form here.
+        self.init(
+            writeKey: writeKey,
+            ingestionHost: ingestionHost.absoluteString,
+            flushIntervalSeconds: flushIntervalSeconds,
+            debug: debug,
+            maxQueueEvents: maxQueueEvents,
+            maxDiskEvents: maxDiskEvents,
+            trackLifecycleEvents: trackLifecycleEvents,
+            onConfigError: onConfigError
+        )
     }
-}
 
-extension InitOptions {
     public init(
         writeKey: String,
         ingestionHost: String,
@@ -48,23 +89,98 @@ extension InitOptions {
         debug: Bool = false,
         maxQueueEvents: Int = 2000,
         maxDiskEvents: Int = 10000,
-        trackLifecycleEvents: Bool = false
+        trackLifecycleEvents: Bool = false,
+        onConfigError: (@Sendable (ConfigError) -> Void)? = nil
     ) {
         var host = ingestionHost.trimmingCharacters(in: .whitespacesAndNewlines)
         if host.hasSuffix("/") {
             host.removeLast()
         }
-        guard let url = URL(string: host), url.scheme != nil else {
-            preconditionFailure("Invalid ingestionHost: \(ingestionHost)")
-        }
         self.init(
-            writeKey: writeKey,
-            ingestionHost: url,
+            core: writeKey,
+            host: URL(string: host),
+            rawHost: ingestionHost,
             flushIntervalSeconds: flushIntervalSeconds,
             debug: debug,
             maxQueueEvents: maxQueueEvents,
             maxDiskEvents: maxDiskEvents,
-            trackLifecycleEvents: trackLifecycleEvents
+            trackLifecycleEvents: trackLifecycleEvents,
+            onConfigError: onConfigError
         )
+    }
+
+    /// Single validation funnel for both public initializers. Records the first
+    /// error (writeKey, then host) instead of trapping; numeric bounds clamp with a
+    /// warning — one policy for all three fields, where previously two clamped
+    /// silently and one crashed the process.
+    private init(
+        core writeKey: String,
+        host: URL?,
+        rawHost: String,
+        flushIntervalSeconds: Int,
+        debug: Bool,
+        maxQueueEvents: Int,
+        maxDiskEvents: Int,
+        trackLifecycleEvents: Bool,
+        onConfigError: (@Sendable (ConfigError) -> Void)?
+    ) {
+        var error: ConfigError?
+
+        let trimmedKey = writeKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedKey.isEmpty {
+            error = .emptyWriteKey
+        }
+
+        let resolvedHost: URL
+        // The scheme check alone is not enough: Foundation parses "https:/" (what a
+        // bare "https://" becomes after the slash trim) as scheme with a nil host,
+        // which would build a live client that fails every request at network time.
+        if let host, let scheme = host.scheme?.lowercased(), scheme == "http" || scheme == "https",
+           let hostName = host.host, !hostName.isEmpty {
+            resolvedHost = host
+            // A cleartext origin is spoofable in transit — legitimate for local
+            // development, worth a warning anywhere else.
+            if scheme == "http", !LoopbackHost.isLoopback(hostName) {
+                Logger.warn(
+                    "ingestionHost \(host.absoluteString) is cleartext http — use https "
+                        + "outside local development."
+                )
+            }
+        } else {
+            if error == nil {
+                error = .invalidIngestionHost(rawHost)
+            }
+            resolvedHost = host ?? Self.unsetHost
+        }
+
+        // One clamp-with-warning policy for every numeric bound — a silent override
+        // and a loud one are two policies.
+        if flushIntervalSeconds < 1 {
+            Logger.warn("flushIntervalSeconds (\(flushIntervalSeconds)) clamped to 1")
+        }
+        if maxQueueEvents < 1 {
+            Logger.warn("maxQueueEvents (\(maxQueueEvents)) clamped to 1")
+        }
+        if maxDiskEvents < 0 {
+            Logger.warn("maxDiskEvents (\(maxDiskEvents)) clamped to 0 — use 0 to disable disk persistence")
+        }
+
+        if let error {
+            InitOptions.debugAssert("Invalid InitOptions: \(error.description)")
+        }
+
+        self.writeKey = trimmedKey
+        self.ingestionHost = resolvedHost
+        self.flushIntervalSeconds = max(1, flushIntervalSeconds)
+        self.debug = debug
+        self.maxQueueEvents = max(1, maxQueueEvents)
+        self.maxDiskEvents = max(0, maxDiskEvents)
+        self.trackLifecycleEvents = trackLifecycleEvents
+        self.configError = error
+        self.onConfigError = onConfigError
+
+        if self.maxDiskEvents > 0 && self.maxDiskEvents < self.maxQueueEvents {
+            Logger.warn("maxDiskEvents (\(self.maxDiskEvents)) is less than maxQueueEvents (\(self.maxQueueEvents)) — memory can hold more events than disk can preserve; events may be dropped during background flush")
+        }
     }
 }

--- a/Sources/MetaRouter/utils/LoopbackHost.swift
+++ b/Sources/MetaRouter/utils/LoopbackHost.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Single definition of "local development host" for cleartext-http warnings —
+/// the config validator and the webview bridge share the same policy, and a
+/// second copy of this list is how the two would quietly diverge.
+internal enum LoopbackHost {
+    static func isLoopback(_ host: String) -> Bool {
+        // URL.host reports IPv6 literals without brackets; origin strings carry them.
+        let name = host.hasPrefix("[") && host.hasSuffix("]")
+            ? String(host.dropFirst().dropLast())
+            : host
+        return name == "localhost" || name == "127.0.0.1" || name == "::1"
+    }
+}

--- a/Sources/MetaRouter/webview/WebViewBridge.swift
+++ b/Sources/MetaRouter/webview/WebViewBridge.swift
@@ -18,8 +18,10 @@ import WebKit
 internal enum WebViewBridge {
 
     // Origin rules must be scheme://host[:port] — anything else (paths, trailing
-    // slashes, wildcards) silently never matches the exact-origin checks.
-    private static let originRule = "^https?://[A-Za-z0-9.-]+(:\\d+)?$"
+    // slashes, wildcards) silently never matches the exact-origin checks. The host
+    // alternation carries bracketed IPv6 literals so http://[::1]:3000 reaches the
+    // loopback check below instead of being rejected as a malformed rule.
+    private static let originRule = "^https?://([A-Za-z0-9.-]+|\\[[0-9A-Fa-f:]+\\])(:\\d+)?$"
 
     // WebKit retains the registered handler for the userContentController's lifetime;
     // tracking attached WebViews weakly means a destroyed WebView is never pinned by

--- a/Sources/MetaRouter/webview/WebViewBridge.swift
+++ b/Sources/MetaRouter/webview/WebViewBridge.swift
@@ -60,9 +60,10 @@ internal enum WebViewBridge {
             )
             return false
         }
-        let insecure = origins.filter {
-            $0.hasPrefix("http://") && $0 != "http://localhost" && !$0.hasPrefix("http://localhost:")
-                && $0 != "http://127.0.0.1" && !$0.hasPrefix("http://127.0.0.1:")
+        let insecure = origins.filter { origin in
+            // Origins here already passed the rule pattern, so URL parsing cannot fail
+            // in practice; an unparseable http rule warns rather than slipping through.
+            origin.hasPrefix("http://") && !LoopbackHost.isLoopback(URL(string: origin)?.host ?? "")
         }
         if !insecure.isEmpty {
             // A cleartext origin is spoofable in transit, and the frame-origin check

--- a/Tests/MetaRouterTests/InitOptionsTests.swift
+++ b/Tests/MetaRouterTests/InitOptionsTests.swift
@@ -1,7 +1,32 @@
 import XCTest
 @testable import MetaRouter
 
+/// Collects debug-assert messages: assertions are active in test builds, so the
+/// release-degrade path is only testable with the fail-fast hook swapped out.
+private final class AssertCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _messages: [String] = []
+    var messages: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _messages
+    }
+    func append(_ message: String) {
+        lock.lock(); defer { lock.unlock() }
+        _messages.append(message)
+    }
+}
+
 final class InitOptionsTests: XCTestCase {
+
+    private func withCapturedAsserts(_ body: () -> InitOptions) -> (options: InitOptions, asserts: [String]) {
+        let capture = AssertCapture()
+        let original = InitOptions.debugAssert
+        InitOptions.debugAssert = { capture.append($0) }
+        defer { InitOptions.debugAssert = original }
+        let options = body()
+        return (options, capture.messages)
+    }
+
     func testInitOptionsFromStringRemovesTrailingSlash() {
         let options = InitOptions(writeKey: "wk", ingestionHost: "https://example.com/")
         XCTAssertEqual(options.writeKey, "wk")
@@ -111,5 +136,206 @@ final class InitOptionsTests: XCTestCase {
             trackLifecycleEvents: true
         )
         XCTAssertTrue(stringOptions.trackLifecycleEvents)
+    }
+
+    // MARK: - Invalid-config contract: assert in debug, record + degrade in release
+
+    func testEmptyWriteKeyRecordsConfigErrorInsteadOfTrapping() {
+        let (options, asserts) = withCapturedAsserts {
+            InitOptions(writeKey: "", ingestionHost: "https://example.com")
+        }
+
+        XCTAssertEqual(options.configError, .emptyWriteKey)
+        XCTAssertEqual(asserts.count, 1, "debug builds fail fast at the construction site")
+    }
+
+    func testWhitespaceOnlyWriteKeyIsRejected() {
+        // Heals the platform divergence: iOS accepted " " while Android rejected it.
+        let (options, _) = withCapturedAsserts {
+            InitOptions(writeKey: "   ", ingestionHost: "https://example.com")
+        }
+
+        XCTAssertEqual(options.configError, .emptyWriteKey)
+    }
+
+    func testWriteKeyIsStoredTrimmed() {
+        let options = InitOptions(writeKey: "  wk  ", ingestionHost: "https://example.com")
+
+        XCTAssertEqual(options.writeKey, "wk")
+        XCTAssertNil(options.configError)
+    }
+
+    func testNonHTTPSchemeRecordsInvalidIngestionHost() {
+        // Unified scheme policy (Android's): http/https only.
+        let (options, asserts) = withCapturedAsserts {
+            InitOptions(writeKey: "wk", ingestionHost: "ftp://example.com")
+        }
+
+        XCTAssertEqual(options.configError, .invalidIngestionHost("ftp://example.com"))
+        XCTAssertEqual(asserts.count, 1)
+    }
+
+    func testUnparseableHostRecordsInvalidIngestionHostWithOriginalString() {
+        let (options, _) = withCapturedAsserts {
+            InitOptions(writeKey: "wk", ingestionHost: "not a url")
+        }
+
+        XCTAssertEqual(options.configError, .invalidIngestionHost("not a url"))
+    }
+
+    func testTrailingSlashOnURLInitIsTrimmedNotRejected() {
+        // Previously a release trap; a cosmetic slash must never disable analytics.
+        let options = InitOptions(writeKey: "wk", ingestionHost: URL(string: "https://example.com/")!)
+
+        XCTAssertNil(options.configError)
+        XCTAssertEqual(options.ingestionHost.absoluteString, "https://example.com")
+    }
+
+    func testNegativeMaxDiskEventsClampsToZeroWithWarning() {
+        // Previously a release trap; now the same clamp-with-warn policy as the
+        // other numeric fields.
+        var options: InitOptions?
+        let output = captureStderrAndStdout {
+            options = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                maxDiskEvents: -5
+            )
+        }
+
+        XCTAssertNil(options?.configError)
+        XCTAssertEqual(options?.maxDiskEvents, 0)
+        XCTAssertTrue(output.contains("clamped"), "clamp should warn, got: \(output)")
+    }
+
+    func testCleartextHTTPWarnsButIsAccepted() {
+        var options: InitOptions?
+        let output = captureStderrAndStdout {
+            options = InitOptions(writeKey: "wk", ingestionHost: "http://api.example.com")
+        }
+
+        XCTAssertNil(options?.configError)
+        XCTAssertTrue(output.contains("cleartext"), "non-loopback http should warn, got: \(output)")
+
+        let local = captureStderrAndStdout {
+            options = InitOptions(writeKey: "wk", ingestionHost: "http://localhost:9999")
+        }
+        XCTAssertNil(options?.configError)
+        XCTAssertFalse(local.contains("cleartext"), "loopback http is a dev setup, no warning")
+    }
+
+    func testHostlessURLRecordsInvalidIngestionHost() {
+        // Foundation parses "https:/" (what a bare "https://" becomes after the slash
+        // trim) as a valid scheme with a nil host — the scheme check alone would build
+        // a live client that fails every request at network time.
+        let (options, _) = withCapturedAsserts {
+            InitOptions(writeKey: "wk", ingestionHost: "https://")
+        }
+
+        XCTAssertEqual(options.configError, .invalidIngestionHost("https://"))
+    }
+
+    func testAllNumericBoundsClampWithAWarning() {
+        // One policy for every numeric field — previously two clamped silently.
+        let output = captureStderrAndStdout {
+            _ = InitOptions(
+                writeKey: "wk",
+                ingestionHost: URL(string: "https://example.com")!,
+                flushIntervalSeconds: 0,
+                maxQueueEvents: 0
+            )
+        }
+
+        XCTAssertTrue(output.contains("flushIntervalSeconds"), "got: \(output)")
+        XCTAssertTrue(output.contains("maxQueueEvents"), "got: \(output)")
+    }
+
+    func testIPv6LoopbackHTTPDoesNotWarn() {
+        var options: InitOptions?
+        let output = captureStderrAndStdout {
+            options = InitOptions(writeKey: "wk", ingestionHost: "http://[::1]:9999")
+        }
+
+        XCTAssertNil(options?.configError)
+        XCTAssertFalse(output.contains("cleartext"), "IPv6 loopback is a dev setup, no warning")
+    }
+
+    func testSchemeCheckIsCaseInsensitive() {
+        let (options, asserts) = withCapturedAsserts {
+            InitOptions(writeKey: "wk", ingestionHost: "HTTPS://example.com")
+        }
+
+        XCTAssertNil(options.configError)
+        XCTAssertTrue(asserts.isEmpty)
+    }
+
+    func testValidConfigFiresNoAssertAndRecordsNoError() {
+        let (options, asserts) = withCapturedAsserts {
+            InitOptions(writeKey: "wk", ingestionHost: "https://example.com")
+        }
+
+        XCTAssertNil(options.configError)
+        XCTAssertTrue(asserts.isEmpty)
+    }
+
+    func testInvalidConfigLeavesSDKInertAndSignals() async {
+        await MetaRouter.Analytics.resetAndWait()
+        let callbackCapture = AssertCapture()
+        let (options, _) = withCapturedAsserts {
+            InitOptions(
+                writeKey: "",
+                ingestionHost: "https://example.com",
+                onConfigError: { callbackCapture.append($0.description) }
+            )
+        }
+
+        let analytics = await MetaRouter.Analytics.initializeAndWait(with: options)
+        // The one behavior this epic exists for: calls on a misconfigured SDK are
+        // inert, never fatal.
+        analytics.track("must_not_crash")
+
+        XCTAssertEqual(callbackCapture.messages.count, 1)
+        // No client was created: debug info stays in bootstrap (proxy) form and
+        // carries the config error for the session. Polled: the proxy seeds its
+        // bootstrap info from a fire-and-forget Task.
+        var sawError = false
+        for _ in 0..<50 where !sawError {
+            let info = await analytics.getDebugInfo()
+            sawError = info["configError"] != nil && info["proxy"]?.boolValue == true
+            if !sawError { try? await Task.sleep(nanoseconds: 20_000_000) }
+        }
+        XCTAssertTrue(sawError, "getDebugInfo should report the config error on the unbound proxy")
+
+        // Awaiting APIs resolve degraded instead of suspending on a bind that will
+        // never come — a permanent hang would be worse than the crash this replaces.
+        let anonymousId = await analytics.getAnonymousId()
+        XCTAssertEqual(anonymousId, "", "config-disabled session returns empty, promptly")
+
+        await MetaRouter.Analytics.resetAndWait()
+    }
+
+    func testInvalidReInitDisablesThePreviousSessionInsteadOfMaskingTheError() async {
+        await MetaRouter.Analytics.resetAndWait()
+        let valid = InitOptions(writeKey: "wk", ingestionHost: "https://example.com")
+        _ = await MetaRouter.Analytics.initializeAndWait(with: valid)
+
+        let (invalid, _) = withCapturedAsserts {
+            InitOptions(writeKey: "", ingestionHost: "https://example.com")
+        }
+        let analytics = await MetaRouter.Analytics.initializeAndWait(with: invalid)
+
+        // The stale valid client must not keep running past an explicit re-init with
+        // bad config — that would silently mask the error (a bound client also
+        // shadows the bootstrap debug info that reports it). Polled: the proxy seeds
+        // bootstrap info from a fire-and-forget Task.
+        var observed = false
+        for _ in 0..<50 where !observed {
+            let info = await analytics.getDebugInfo()
+            observed = info["proxy"]?.boolValue == true && info["configError"] != nil
+            if !observed { try? await Task.sleep(nanoseconds: 20_000_000) }
+        }
+        XCTAssertTrue(observed, "previous client unbound and config error observable")
+
+        await MetaRouter.Analytics.resetAndWait()
     }
 }

--- a/Tests/MetaRouterTests/InitOptionsTests.swift
+++ b/Tests/MetaRouterTests/InitOptionsTests.swift
@@ -338,4 +338,28 @@ final class InitOptionsTests: XCTestCase {
 
         await MetaRouter.Analytics.resetAndWait()
     }
+
+    func testResetClearsTheConfigRefusalSoTheNextSessionCanBind() async {
+        await MetaRouter.Analytics.resetAndWait()
+        let (invalid, _) = withCapturedAsserts {
+            InitOptions(writeKey: "", ingestionHost: "https://example.com")
+        }
+        _ = await MetaRouter.Analytics.initializeAndWait(with: invalid)
+
+        // reset() ends the refused session. The refusal must not survive it: a
+        // following valid init has to produce a live client, and awaiting APIs must
+        // resolve against that client rather than the previous session's verdict.
+        await MetaRouter.Analytics.resetAndWait()
+
+        let valid = InitOptions(writeKey: "wk", ingestionHost: "https://example.com")
+        let analytics = await MetaRouter.Analytics.initializeAndWait(with: valid)
+
+        let anonymousId = await analytics.getAnonymousId()
+        XCTAssertFalse(anonymousId.isEmpty, "recovered session must resolve a real anonymousId, not the degraded empty string")
+
+        let info = await analytics.getDebugInfo()
+        XCTAssertNil(info["configError"], "stale config error must not follow a reset into a healthy session")
+
+        await MetaRouter.Analytics.resetAndWait()
+    }
 }

--- a/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
+++ b/Tests/MetaRouterTests/webview/WebViewBridgeTests.swift
@@ -71,6 +71,21 @@ final class WebViewBridgeTests: XCTestCase {
     }
 
     @MainActor
+    func testAttachAcceptsBracketedIPv6LoopbackOrigins() {
+        let webView = WKWebView()
+        let (_, processor) = makeProcessor()
+
+        // The IPv6 loopback is a normal local-development origin. It has to clear the
+        // rule pattern to reach the loopback check, or the cleartext-http allowance
+        // for ::1 never applies to the bridge at all.
+        XCTAssertTrue(WebViewBridge.attach(webView, allowedOrigins: ["http://[::1]:3000"], processor: processor))
+
+        // A bracketed literal is still a host, not a licence to skip the format rules.
+        let other = WKWebView()
+        XCTAssertFalse(WebViewBridge.attach(other, allowedOrigins: ["http://[::1]:3000/path"], processor: processor))
+    }
+
+    @MainActor
     func testOriginRulesAreNormalizedSoCaseAndDefaultPortVariantsMatch() {
         // Scheme/host case and explicit default ports pass validation but would never
         // match the canonical origin the page reports — normalized at attach so the


### PR DESCRIPTION
**Shortcut:** [sc-40638](https://app.shortcut.com/metarouter/story/40638) · contract ratified on [sc-40637](https://app.shortcut.com/metarouter/story/40637)
**Epic:** [40636 — crash-safety](https://app.shortcut.com/metarouter/epic/40636) (Wave 1)
**Android:** sc-40639 ports from this PR once approved (this PR is the reference implementation, bridge-style in reverse).

## The contract (condensed — this is the sc-40637 decision)

**Construction never fails.** Validation runs at construction and records the first error into `InitOptions.configError`; debug builds fail fast via an assertion (injectable, so the release path is testable). **`initialize()` reads the verdict**: logs an always-on error, fires the optional `onConfigError` callback (new, rides `InitOptions`), and returns the proxy with **no client created** — inert session, mirroring the 401/403/404 graceful-disable for local config.

Why not a throwing/failable initializer: (1) the diagnostics callback needs an object to live on; (2) remote-config-sourced keys invite `try!`, recreating the crash; (3) Android cannot detect debuggability without a `Context`, which only exists at initialize — so the debug/release fork must live there on both platforms.

| Input | Unified rule |
|---|---|
| writeKey | trimmed; empty/whitespace-only → `emptyWriteKey` |
| host | http/https only (case-insensitive) **and non-empty host** (`"https:/"` parses as scheme-with-nil-host) |
| cleartext http | warn unless loopback (`localhost` / `127.0.0.1` / `::1` — shared `LoopbackHost`, also used by the bridge) |
| trailing slash | trimmed everywhere, never fatal |
| numerics | clamp + warn, all three fields, one policy |
| multiple errors | first wins (writeKey, then host) |

**Degraded-session semantics** (from adversarial review of this diff): suspending APIs resolve instead of hanging (`getAnonymousId` → `""` promptly — a permanent hang is worse than the crash this replaces); an invalid **re-**initialize disables the running session rather than silently keeping the stale client (which would shadow the very debug info reporting the error); `getDebugInfo()` carries `configError` for the session.

## Versioning

`ConfigError` + `onConfigError` are new public API → **minor release, not patch**.

## Deferred, recorded

Gate-inside-`AnalyticsClient.initialize` (defense against future ungated internal callers): no live bypass exists today; the honest fix ripples through every client-constructing test. Queued for the lifecycle-state hardening pass.

## Test plan

- [x] 25 `InitOptionsTests` incl. one per contract row, previously-untestable crash paths now asserted via the injectable debug hook
- [x] End-to-end: misconfigured SDK → `track()` inert, callback fires once, `getDebugInfo` reports the error, `getAnonymousId` resolves promptly
- [x] Invalid re-init over a valid session → previous client unbound, error observable
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)